### PR TITLE
Added icon to add new empty entity

### DIFF
--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -76,6 +76,10 @@ export default class Main extends React.Component {
     this.setState({isModalTexturesOpen: true});
   }
 
+  addEntity() {
+    Events.emit('createNewEntity', {element: 'a-entity', components: []});
+  }
+
   render() {
     var scene = document.querySelector('a-scene');
     var toggleText = this.state.editorEnabled;
@@ -90,6 +94,7 @@ export default class Main extends React.Component {
             <Scenegraph scene={scene}/>
             <div className="scenegraph-bottom">
               <a href="#" title="Delete selected entity" onClick={this.deleteEntity} className="button fa fa-trash-o"></a>
+              <a href="#" title="Add new entity" onClick={this.addEntity} className="button fa fa-plus"></a>
             </div>
           </div>
           <AttributesSidebar/>


### PR DESCRIPTION
Add a '[+]' icon on the scenegraph toolbar to add an empty entity to the scene

<img width="179" alt="screenshot 2016-07-07 01 20 40" src="https://cloud.githubusercontent.com/assets/782511/16637673/16c9ac52-43e1-11e6-93c2-c2fda7eb3c4e.png">
