### PR TITLE
use monospace font for tag name (fixes #41)

### DIFF
--- a/src/components/attributes/CommonComponents.js
+++ b/src/components/attributes/CommonComponents.js
@@ -116,11 +116,11 @@ const CommonComponents = props => {
   return (
     <Collapsible>
       <div className="collapsible-header">
-        <span>COMMON</span>
+        <span>Common</span>
       </div>
       <div className="collapsible-content">
         <div className="row">
-          <span className="value">&lt;{entity.tagName.toLowerCase()}&gt;</span>
+          <span className="value tagName"><code>&lt;{entity.tagName.toLowerCase()}&gt;</code></span>
         </div>
         <div className="row">
           <span className="text">ID</span>

--- a/src/css/dark.css
+++ b/src/css/dark.css
@@ -317,11 +317,9 @@ div.vec3 {
   width: 50px;
 }
 
-.collapsible {
-}
-
-.collapsible .static span {
+.collapsible-header span {
   float: left;
+  text-transform: uppercase;
 }
 
 .collapsible .static {
@@ -335,15 +333,15 @@ div.vec3 {
 }
 
 .collapsible .menu {
-  text-align:right;
+  text-align: right;
 }
 
 .collapsible .menu:after {
+  color: #1faaf2;
   content: '\2807';
   font-size: 12px;
-  color: #1faaf2;
-  text-align:right;
   padding: 5px;
+  text-align: right;
 }
 
 .collapsible .static .button {
@@ -749,4 +747,12 @@ span.subcomponent {
   cursor: grabbing;
   cursor: -moz-grabbing;
   cursor: -webkit-grabbing;
+}
+
+code, pre {
+  font-family: Consolas, Andale Mono, Monaco, Courier New, monospace;
+}
+
+.tagName {
+  font-weight: 500;
 }


### PR DESCRIPTION
#### before

<img width="1240" alt="screen shot 2016-07-07 at 2 25 06 am" src="https://cloud.githubusercontent.com/assets/203725/16648726/441dcff4-43ea-11e6-91ed-bf47faad12fa.png">
#### after

<img width="1240" alt="screen shot 2016-07-07 at 2 27 33 am" src="https://cloud.githubusercontent.com/assets/203725/16648757/6273fec4-43ea-11e6-8377-8ad80b768f10.png">
