### PR TITLE
enable HMR (hot module replacement) (fixes #120)

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -55,6 +55,7 @@
           position="0 0 0">
       </a-entity>
     </a-scene>
-    <script src="../build/aframe-editor.js"></script>
+
+    <script src="http://localhost:3333/build/aframe-editor.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "An editor for A-Frame scenes.",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --progress --colors -d --open",
-    "build": "webpack --progress --colors -p",
+    "build": "NODE_ENV=production webpack --progress --colors -p",
+    "ghpages": "npm run preghpages && node ./scripts/gh-pages",
     "lint": "npm run lintfile src/",
     "lintfile": "node --harmony node_modules/.bin/eslint",
-    "preghpages": "npm run build && shx rm -rf gh-pages && shx mkdir gh-pages",
-    "ghpages": "npm run preghpages && shx cp -r build example gh-pages && node ./scripts/gh-pages"
+    "preghpages": "npm run build && shx rm -rf gh-pages && shx mkdir gh-pages && shx cp -r build example index.html gh-pages && shx sed -i http://localhost:3333 .. gh-pages/example/index.html",
+    "start": "NODE_ENV=dev webpack-dev-server --progress --colors --hot -d --open"
   },
   "repository": "aframevr/aframe-editor",
   "license": "MIT",
@@ -32,9 +32,11 @@
     "eslint-plugin-standard": "^1.3.2",
     "gh-pages": "^0.11.0",
     "open": "0.0.5",
+    "postcss-import": "^8.1.2",
     "postcss-loader": "^0.9.1",
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
+    "shx": "^0.1.2",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.1",
     "webpack-dev-server": "^1.14.1"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,25 @@
+var path = require('path');
+
 var autoprefixer = require('autoprefixer');
+var postcssImport = require('postcss-import');
+var webpack = require('webpack');
+
+// Add HMR for development environments only.
+var entry = ['./src/components/Main.js'];
+if (process.env.NODE_ENV === 'dev') {
+  entry = [
+    'webpack-dev-server/client?http://localhost:3333',
+    'webpack/hot/only-dev-server'
+  ].concat(entry);
+}
 
 module.exports = {
-  entry: "./src/components/Main.js",
+  devServer: {port: 3333},
+  entry: entry,
   output: {
-    filename: "build/aframe-editor.js",
-  },
-  devServer: {
-    inline: true,
-    port: 3333
+    path: path.join(__dirname, 'build'),
+    filename: 'aframe-editor.js',
+    publicPath: '/build/'
   },
   module: {
     loaders: [
@@ -26,7 +38,10 @@ module.exports = {
       }
     ]
   },
-  postcss: function () {
-    return [autoprefixer];
+  postcss: function (webpack) {
+    return [
+      postcssImport({addDependencyTo: webpack}),  // postcss/postcss-loader/issues/8
+      autoprefixer
+    ];
   }
 };


### PR DESCRIPTION
- Have `example/` read the served in-memory Webpack bundle.
- In production, use the build file without HMR using `sed`.
- Set `NODE_ENV` to production to appropriately minify React.
