### PR TITLE
Add transforms toolbar and make panel titles much smaller

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-plugin-transform-class-properties": "^6.10.2",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
+    "classnames": "^2.2.5",
     "css-loader": "^0.23.1",
     "eslint": "^2.9.x",
     "eslint-config-standard": "^5.3.1",

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -7,6 +7,7 @@ import AttributesSidebar from './attributes/AttributesSidebar';
 import {MenuWidget} from './menu/Menu';
 import ModalTextures from './modals/ModalTextures';
 import SceneGraph from './SceneGraph';
+import ToolBar from './ToolBar';
 
 import "../css/main.css";
 import "../css/dark.css";
@@ -76,9 +77,10 @@ export default class Main extends React.Component {
       <div>
         <div id="editor" className={this.state.editorEnabled ? '' : 'hidden'}>
           <ModalTextures ref="modaltextures" isOpen={textureDialogOpened} onClose={this.onModalTextureOnClose}/>
+          <ToolBar/>
           <MenuWidget/>
           <div id="sidebar-left">
-            <div className="tab">SCENEGRAPH</div>
+            <div className="sidebar-title">scenegraph</div>
             <SceneGraph scene={scene}/>
           </div>
           <AttributesSidebar/>

--- a/src/components/ToolBar.js
+++ b/src/components/ToolBar.js
@@ -1,0 +1,58 @@
+var React = require('react');
+var Events = require('../lib/Events.js');
+var classNames = require('classnames');
+
+var TransformButtons = [
+  {value: 'translate', icon: 'fa-arrows'},
+  {value: 'rotate', icon: 'fa-repeat'},
+  {value: 'scale', icon: 'fa-expand'}
+];
+
+export default class ToolBar extends React.Component {
+  constructor (props) {
+    super(props);
+    this.state = {selectedTransform: 'translate', localSpace: false};
+  }
+
+  changeTransformMode = mode => {
+    this.setState({selectedTransform: mode});
+    Events.emit('transformModeChanged', mode);
+  }
+
+  onLocalChange = e => {
+    var local = e.target.checked;
+    this.setState({localSpace: local});
+    Events.emit('spaceChanged', local ? 'local' : 'world');
+  }
+
+  renderTransformButtons = () => {
+    return TransformButtons.map(function (option) {
+      var selected = option.value === this.state.selectedTransform;
+      var classes = classNames({
+        button: true,
+        fa: true,
+        [option.icon]: true,
+        active: selected
+      });
+
+      return <a href='#' title={option.value}
+        onClick={this.changeTransformMode.bind(this, option.value)}
+        className={classes}></a>;
+    }.bind(this));
+  }
+
+  render () {
+    return (
+      <div className='toolbar'>
+        {this.renderTransformButtons()}
+        <span className='local-transform'>
+          <input id='local' type='checkbox'
+            checked={this.state.localSpace || this.state.selectedTransform === 'scale'}
+            disabled={this.state.selectedTransform === 'scale'}
+            onChange={this.onLocalChange}/>
+          <label htmlFor='local'>local</label>
+        </span>
+      </div>
+    );
+  }
+}

--- a/src/components/attributes/AttributesSidebar.js
+++ b/src/components/attributes/AttributesSidebar.js
@@ -15,14 +15,7 @@ export default class AttributesSidebar extends React.Component {
   render() {
     return (
       <div id="sidebar">
-        <div className="tab collapsible">
-          <span>ATTRIBUTES</span>
-          <div className="dropdown menu hide">
-            <div className="dropdown-content">
-              <a href="#" onClick={this.deleteComponent}>Collapse all</a>
-            </div>
-          </div>
-        </div>
+        <div className="sidebar-title">attributes</div>
         <AttributesPanel/>
       </div>
     );

--- a/src/css/dark.css
+++ b/src/css/dark.css
@@ -235,29 +235,6 @@ input.number:focus {
     background-color: #111;
   }
 
-#toolbar {
-  position: absolute;
-  left: 0;
-  right: 330px;
-  bottom: 0;
-  height: 32px;
-  background-color: #111;
-  color: #333;
-}
-
-  #toolbar * {
-    vertical-align: middle;
-  }
-
-  #toolbar .Panel {
-    padding: 4px;
-    color: #888;
-  }
-
-  #toolbar button {
-    margin-right: 6px;
-  }
-
 .aframe-logo {
   background-color: #424242;
   margin-right: 10px;
@@ -766,6 +743,58 @@ code, pre {
 
 .tagName {
   font-weight: 500;
+}
+
+.sidebar-title {
+  color: #1faaf2;
+  text-align: center;
+  background-color: #323232;
+  padding: 2px;
+  border-top: 2px solid #1faaf2;
+  font-size: 10px;
+}
+
+.toolbar {
+  position: absolute;
+  right: 330px;
+  top: 34px;
+  height: 32px;
+  background-color: #262626;
+  color: #333;
+}
+
+.toolbar * {
+  vertical-align: middle;
+  padding: 8px;
+  margin-left: 0px;
+  /*margin-top: 7px;*/
+}
+
+
+.toolbar a.button {
+  margin: 0 6px 0 0;
+}
+
+.toolbar .active {
+  background-color: #1faaf2;
+  color: #fff;
+}
+
+.toolbar .active:hover {
+  color: #fff !important;
+}
+
+.local-transform {
+  padding-left: 10px;
+}
+
+.local-transform label {
+  color: #AAA;
+  padding-left: 5px;
+}
+
+.local-transform a.button {
+  padding-top: 0px;
 }
 
 .outliner {

--- a/src/lib/vendor/threejs/TransformControls.js
+++ b/src/lib/vendor/threejs/TransformControls.js
@@ -1,12 +1,10 @@
 /**
  * @author arodic / https://github.com/arodic
  */
- /*jshint sub:true*/
 
 ( function () {
 
 	'use strict';
-
 
 	var GizmoMaterial = function ( parameters ) {
 
@@ -281,15 +279,15 @@
 		this.pickerGizmos = {
 
 			X: [
-				[ new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), pickerMaterial ), [ 0.6, 0, 0 ], [ 0, 0, - Math.PI / 2 ] ]
+				[ new THREE.Mesh( new THREE.CylinderBufferGeometry( 0.2, 0, 1, 4, 1, false ), pickerMaterial ), [ 0.6, 0, 0 ], [ 0, 0, - Math.PI / 2 ] ]
 			],
 
 			Y: [
-				[ new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), pickerMaterial ), [ 0, 0.6, 0 ] ]
+				[ new THREE.Mesh( new THREE.CylinderBufferGeometry( 0.2, 0, 1, 4, 1, false ), pickerMaterial ), [ 0, 0.6, 0 ] ]
 			],
 
 			Z: [
-				[ new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), pickerMaterial ), [ 0, 0, 0.6 ], [ Math.PI / 2, 0, 0 ] ]
+				[ new THREE.Mesh( new THREE.CylinderBufferGeometry( 0.2, 0, 1, 4, 1, false ), pickerMaterial ), [ 0, 0, 0.6 ], [ Math.PI / 2, 0, 0 ] ]
 			],
 
 			XYZ: [
@@ -406,19 +404,19 @@
 		this.pickerGizmos = {
 
 			X: [
-				[ new THREE.Mesh( new THREE.TorusGeometry( 1, 0.12, 4, 12, Math.PI ), pickerMaterial ), [ 0, 0, 0 ], [ 0, - Math.PI / 2, - Math.PI / 2 ] ]
+				[ new THREE.Mesh( new THREE.TorusBufferGeometry( 1, 0.12, 4, 12, Math.PI ), pickerMaterial ), [ 0, 0, 0 ], [ 0, - Math.PI / 2, - Math.PI / 2 ] ]
 			],
 
 			Y: [
-				[ new THREE.Mesh( new THREE.TorusGeometry( 1, 0.12, 4, 12, Math.PI ), pickerMaterial ), [ 0, 0, 0 ], [ Math.PI / 2, 0, 0 ] ]
+				[ new THREE.Mesh( new THREE.TorusBufferGeometry( 1, 0.12, 4, 12, Math.PI ), pickerMaterial ), [ 0, 0, 0 ], [ Math.PI / 2, 0, 0 ] ]
 			],
 
 			Z: [
-				[ new THREE.Mesh( new THREE.TorusGeometry( 1, 0.12, 4, 12, Math.PI ), pickerMaterial ), [ 0, 0, 0 ], [ 0, 0, - Math.PI / 2 ] ]
+				[ new THREE.Mesh( new THREE.TorusBufferGeometry( 1, 0.12, 4, 12, Math.PI ), pickerMaterial ), [ 0, 0, 0 ], [ 0, 0, - Math.PI / 2 ] ]
 			],
 
 			E: [
-				[ new THREE.Mesh( new THREE.TorusGeometry( 1.25, 0.12, 2, 24 ), pickerMaterial ) ]
+				[ new THREE.Mesh( new THREE.TorusBufferGeometry( 1.25, 0.12, 2, 24 ), pickerMaterial ) ]
 			],
 
 			XYZE: [
@@ -544,7 +542,7 @@
 			],
 
 			XYZ: [
-				[ new THREE.Mesh( new THREE.BoxGeometry( 0.125, 0.125, 0.125 ), new GizmoMaterial( { color: 0xffffff, opacity: 0.25 } ) ) ]
+				[ new THREE.Mesh( new THREE.BoxBufferGeometry( 0.125, 0.125, 0.125 ), new GizmoMaterial( { color: 0xffffff, opacity: 0.25 } ) ) ]
 			]
 
 		};
@@ -552,19 +550,19 @@
 		this.pickerGizmos = {
 
 			X: [
-				[ new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), pickerMaterial ), [ 0.6, 0, 0 ], [ 0, 0, - Math.PI / 2 ] ]
+				[ new THREE.Mesh( new THREE.CylinderBufferGeometry( 0.2, 0, 1, 4, 1, false ), pickerMaterial ), [ 0.6, 0, 0 ], [ 0, 0, - Math.PI / 2 ] ]
 			],
 
 			Y: [
-				[ new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), pickerMaterial ), [ 0, 0.6, 0 ] ]
+				[ new THREE.Mesh( new THREE.CylinderBufferGeometry( 0.2, 0, 1, 4, 1, false ), pickerMaterial ), [ 0, 0.6, 0 ] ]
 			],
 
 			Z: [
-				[ new THREE.Mesh( new THREE.CylinderGeometry( 0.2, 0, 1, 4, 1, false ), pickerMaterial ), [ 0, 0, 0.6 ], [ Math.PI / 2, 0, 0 ] ]
+				[ new THREE.Mesh( new THREE.CylinderBufferGeometry( 0.2, 0, 1, 4, 1, false ), pickerMaterial ), [ 0, 0, 0.6 ], [ Math.PI / 2, 0, 0 ] ]
 			],
 
 			XYZ: [
-				[ new THREE.Mesh( new THREE.BoxGeometry( 0.4, 0.4, 0.4 ), pickerMaterial ) ]
+				[ new THREE.Mesh( new THREE.BoxBufferGeometry( 0.4, 0.4, 0.4 ), pickerMaterial ) ]
 			]
 
 		};
@@ -748,7 +746,7 @@
 
 			_mode = mode ? mode : _mode;
 
-			if ( _mode === "scale" ) scope.space = "local";
+			// if ( _mode === "scale" ) scope.space = "local";
 
 			for ( var type in _gizmo ) _gizmo[ type ].visible = ( type === _mode );
 
@@ -787,11 +785,11 @@
 
 		this.update = function () {
 
-			if ( scope.object !== undefined ) {
-				scope.object.updateMatrixWorld();
-				worldPosition.setFromMatrixPosition( scope.object.matrixWorld );
-				worldRotation.setFromRotationMatrix( tempMatrix.extractRotation( scope.object.matrixWorld ) );
-			}
+			if ( scope.object === undefined ) return;
+
+			scope.object.updateMatrixWorld();
+			worldPosition.setFromMatrixPosition( scope.object.matrixWorld );
+			worldRotation.setFromRotationMatrix( tempMatrix.extractRotation( scope.object.matrixWorld ) );
 
 			camera.updateMatrixWorld();
 			camPosition.setFromMatrixPosition( camera.matrixWorld );
@@ -803,7 +801,7 @@
 
 			eye.copy( camPosition ).sub( worldPosition ).normalize();
 
-			if ( scope.space === "local" ) {
+			if ( scope.space === "local" || _mode === "scale" ) {
 
 				_gizmo[ _mode ].update( worldRotation, eye );
 
@@ -818,11 +816,13 @@
 		};
 
 		function onPointerHover( event ) {
+
 			if ( scope.object === undefined || _dragging === true || ( event.button !== undefined && event.button !== 0 ) ) return;
 
 			var pointer = event.changedTouches ? event.changedTouches[ 0 ] : event;
 
 			var intersect = intersectObjects( pointer, _gizmo[ _mode ].pickers.children );
+
 			var axis = null;
 
 			if ( intersect ) {
@@ -913,7 +913,7 @@
 				point.sub( offset );
 				point.multiply( parentScale );
 
-				if ( scope.space === "local" ) {
+				if ( scope.space === "local" || _mode === "scale" ) {
 
 					point.applyMatrix4( tempMatrix.getInverse( worldRotationMatrix ) );
 
@@ -943,7 +943,7 @@
 
 				if ( scope.translationSnap !== null ) {
 
-					if ( scope.space === "local" ) {
+					if ( scope.space === "local" || _mode === "scale" ) {
 
 						scope.object.position.applyMatrix4( tempMatrix.getInverse( worldRotationMatrix ) );
 
@@ -953,7 +953,7 @@
 					if ( scope.axis.search( "Y" ) !== - 1 ) scope.object.position.y = Math.round( scope.object.position.y / scope.translationSnap ) * scope.translationSnap;
 					if ( scope.axis.search( "Z" ) !== - 1 ) scope.object.position.z = Math.round( scope.object.position.z / scope.translationSnap ) * scope.translationSnap;
 
-					if ( scope.space === "local" ) {
+					if ( scope.space === "local" || _mode === "scale" ) {
 
 						scope.object.position.applyMatrix4( worldRotationMatrix );
 
@@ -966,11 +966,11 @@
 				point.sub( offset );
 				point.multiply( parentScale );
 
-				if ( scope.space === "local" ) {
+				if ( scope.space === "local" || _mode === "scale" ) {
 
 					if ( scope.axis === "XYZ" ) {
 
-						scale = 1 + ( ( point.y ) / 50 );
+						scale = 1 + ( ( point.y ) / Math.max( oldScale.x, oldScale.y, oldScale.z ) );
 
 						scope.object.scale.x = oldScale.x * scale;
 						scope.object.scale.y = oldScale.y * scale;
@@ -980,9 +980,9 @@
 
 						point.applyMatrix4( tempMatrix.getInverse( worldRotationMatrix ) );
 
-						if ( scope.axis === "X" ) scope.object.scale.x = oldScale.x * ( 1 + point.x / 50 );
-						if ( scope.axis === "Y" ) scope.object.scale.y = oldScale.y * ( 1 + point.y / 50 );
-						if ( scope.axis === "Z" ) scope.object.scale.z = oldScale.z * ( 1 + point.z / 50 );
+						if ( scope.axis === "X" ) scope.object.scale.x = oldScale.x * ( 1 + point.x / oldScale.x );
+						if ( scope.axis === "Y" ) scope.object.scale.y = oldScale.y * ( 1 + point.y / oldScale.y );
+						if ( scope.axis === "Z" ) scope.object.scale.z = oldScale.z * ( 1 + point.z / oldScale.z );
 
 					}
 
@@ -1026,7 +1026,7 @@
 
 					scope.object.quaternion.copy( tempQuaternion );
 
-				} else if ( scope.space === "local" ) {
+				} else if ( scope.space === "local" || _mode === "scale" ) {
 
 					point.applyMatrix4( tempMatrix.getInverse( worldRotationMatrix ) );
 
@@ -1100,17 +1100,32 @@
 
 		function onPointerUp( event ) {
 
+			event.preventDefault(); // Prevent MouseEvent on mobile
+
 			if ( event.button !== undefined && event.button !== 0 ) return;
 
 			if ( _dragging && ( scope.axis !== null ) ) {
 
 				mouseUpEvent.mode = _mode;
-				scope.dispatchEvent( mouseUpEvent )
+				scope.dispatchEvent( mouseUpEvent );
 
 			}
 
 			_dragging = false;
-			onPointerHover( event );
+
+			if ( event instanceof TouchEvent ) {
+
+				// Force "rollover"
+
+				scope.axis = null;
+				scope.update();
+				scope.dispatchEvent( changeEvent );
+
+			} else {
+
+				onPointerHover( event );
+
+			}
 
 		}
 
@@ -1119,6 +1134,7 @@
 			var rect = domElement.getBoundingClientRect();
 			var x = ( pointer.clientX - rect.left ) / rect.width;
 			var y = ( pointer.clientY - rect.top ) / rect.height;
+
 			pointerVector.set( ( x * 2 ) - 1, - ( y * 2 ) + 1 );
 			ray.setFromCamera( pointerVector, camera );
 


### PR DESCRIPTION
Split fro https://github.com/aframevr/aframe-editor/pull/148

Added gizmos and support for local and global transforms.
<img width="1067" alt="screenshot 2016-07-08 20 09 30" src="https://cloud.githubusercontent.com/assets/782511/16697018/e920e2bc-4547-11e6-8b32-38dd4da32a31.png">

Video of the gizmos working: https://www.dropbox.com/s/zck3dfwqyrunwto/transforms_gizmos.mov?dl=0

PS: The `transformControls` file doesn't need review directly as I didn't change anything there, it's taken  from the latest threejs version.
