### PR TITLE
Fixes export and copy to clipbard scene issues

### DIFF
--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -66,12 +66,12 @@ export default class Main extends React.Component {
     var textureDialogOpened = this.state.isModalTexturesOpen;
     return (
       <div>
-        <div id="editor" className={this.state.editorEnabled ? '' : 'hidden'}>
-          <ModalTextures ref="modaltextures" isOpen={textureDialogOpened} onClose={this.onModalTextureOnClose}/>
+        <div id='editor' className={this.state.editorEnabled ? '' : 'hidden'}>
+          <ModalTextures ref='modaltextures' isOpen={textureDialogOpened} onClose={this.onModalTextureOnClose}/>
           <ToolBar/>
           <MenuWidget/>
-          <div id="sidebar-left">
-            <div className="sidebar-title">scenegraph</div>
+          <div id='sidebar-left'>
+            <div className='sidebar-title'>scenegraph</div>
             <SceneGraph scene={scene}/>
           </div>
           <AttributesSidebar/>
@@ -90,15 +90,17 @@ function injectCSS (url) {
   link.type = 'text/css';
   link.rel = 'stylesheet';
   link.media = 'screen,print';
+  link.setAttribute('data-aframe-editor', 'style');
   document.getElementsByTagName('head')[0].appendChild(link);
 }
 
 (function init () {
   var div = document.createElement('div');
-  div.id = 'app';
+  div.id = 'aframe-editor';
+  div.setAttribute('data-aframe-editor', 'app');
   document.body.appendChild(div);
   window.addEventListener('editor-loaded', function () {
-    ReactDOM.render(<Main/>, document.getElementById('app'));
+    ReactDOM.render(<Main/>, div);
   });
   window.editor = new Editor();
 })();

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -101,6 +101,7 @@ export class MenuWidget extends React.Component {
   saveToHTML() {
     var link = document.createElement('a');
     link.style.display = 'none';
+    link.setAttribute('data-aframe-editor', 'download');
     document.body.appendChild(link);
     function save (blob, filename) {
       link.href = URL.createObjectURL(blob);

--- a/src/lib/exporter.js
+++ b/src/lib/exporter.js
@@ -16,9 +16,25 @@ module.exports = {
 
     // Remove all the components that are being injected by aframe-editor or aframe
     // @todo Use custom class to prevent this hack
-    Array.prototype.forEach.call(xmlDoc.querySelectorAll('.a-enter-vr,.a-orientation-modal,.Panel,.aframe-editor,.rs-base,.a-canvas,.a-enter-vr-button,style[data-href="style/rStats.css"],style[data-href^="src/panels"],style[data-href="style/aframe-core.css"],link[href^="https://maxcdn.bootstrapcdn.com"]'), function (el) {
+    var elementsToRemove = xmlDoc.querySelectorAll([
+      // Injected by the editor
+      '[data-aframe-editor]',
+      'script[src$="aframe-editor.js"]',
+      'style[type="text/css"]',
+      // Injected by aframe
+      '.a-enter-vr',
+      '.a-orientation-modal',
+      '.a-canvas',
+      '.a-enter-vr-button',
+      'style[data-href$="aframe.css"]',
+      // Injected by stats
+      '.rs-base',
+      'style[data-href$="rStats.css"]'
+    ].join(','));
+    for (var i = 0; i < elementsToRemove.length; i++) {
+      var el = elementsToRemove[i];
       el.parentNode.removeChild(el);
-    });
+    }
 
     return this.xmlToString(xmlDoc);
   }


### PR DESCRIPTION
Delete everything injected by `aframe` or `aframe-editor` when exporting to HTML or copying to clipboard the entire scene.
