### PR TITLE
Remove three-dots contextual menu and add copy to clipboard

### DIFF
--- a/src/components/Collapsible.js
+++ b/src/components/Collapsible.js
@@ -34,7 +34,7 @@ export default class Collapsible extends React.Component {
   	return (
       <div className={'component collapsible' + (collapsed ? ' collapsed' : '')}>
         <div className="static" onClick={this.toggleVisibility}>
-          <div className="button"></div>
+          <div className="collapse-button"></div>
           {this.props.children[0]}
         </div>
         <div className={'content' + (collapsed ? ' hide' : '')}>

--- a/src/components/attributes/CommonComponents.js
+++ b/src/components/attributes/CommonComponents.js
@@ -7,6 +7,8 @@ import Collapsible from '../Collapsible';
 import MixinsComponent from './MixinsComponent';
 import {updateEntity} from '../../actions/entity';
 
+var Clipboard = require('clipboard');
+
 // @todo Take this out and use updateEntity?
 function changeId (entity, componentName, propertyName, value) {
   if (entity.id !== value) {
@@ -15,40 +17,59 @@ function changeId (entity, componentName, propertyName, value) {
   }
 }
 
-const CommonComponents = props => {
-  const entity = props.entity;
-  const components = entity ? props.entity.components : {};
-  if (!entity) { return <div></div>; }
-  return (
-    <Collapsible>
-      <div className='collapsible-header'>
-        <span>Common</span>
-      </div>
-      <div className='collapsible-content'>
-        <div className='row'>
-          <span className='value tagName'><code>&lt;{entity.tagName.toLowerCase()}&gt;</code></span>
+class CommonComponents extends React.Component {
+
+  componentDidMount() {
+    var self = this;
+    var clipboard = new Clipboard('[data-action="copy-entity-to-clipboard"]', {
+      text: function (trigger) {
+        return self.props.entity.outerHTML;
+      }
+    });
+    clipboard.on('error', function(e) {
+        console.error('Error while copying to clipboard:', e.action, e.trigger);
+    });
+  }
+
+  render() {
+    const entity = this.props.entity;
+    const components = entity ? this.props.entity.components : {};
+    if (!entity) { return <div></div>; }
+    return (
+      <Collapsible>
+        <div className='collapsible-header'>
+          <span>Common</span>
+          <div>
+            <a href="#" title="Copy entity to clipboard" data-action="copy-entity-to-clipboard"
+              className="button fa fa-clipboard" onClick={event => event.stopPropagation()}></a>
+          </div>
         </div>
-        <div className='row'>
-          <span className='text'>ID</span>
-          <InputWidget onChange={changeId} entity={entity} name='id' value={entity.id}/>
+        <div className='collapsible-content'>
+          <div className='row'>
+            <span className='value tagName'><code>&lt;{entity.tagName.toLowerCase()}&gt;</code></span>
+          </div>
+          <div className='row'>
+            <span className='text'>ID</span>
+            <InputWidget onChange={changeId} entity={entity} name='id' value={entity.id}/>
+          </div>
+          {
+            Object.keys(components).filter(function (key) {
+              return ['visible', 'position', 'scale', 'rotation'].indexOf(key) !== -1;
+            }).map((key) => {
+              const componentData = components[key];
+              const schema = AFRAME.components[key].schema;
+              return (
+                <AttributeRow onChange={updateEntity} key={key} name={key}
+                              schema={schema} data={componentData.data} componentname={key}
+                              entity={this.props.entity}/>
+              );
+            })
+          }
+          <MixinsComponent entity={entity}/>
         </div>
-        {
-          Object.keys(components).filter(function (key) {
-            return ['visible', 'position', 'scale', 'rotation'].indexOf(key) !== -1;
-          }).map(function (key) {
-            const componentData = components[key];
-            const schema = AFRAME.components[key].schema;
-            return (
-              <AttributeRow onChange={updateEntity} key={key} name={key}
-                            schema={schema} data={componentData.data} componentname={key}
-                            entity={props.entity}/>
-            );
-          })
-        }
-        <MixinsComponent entity={entity}/>
-      </div>
-    </Collapsible>
-  );
+      </Collapsible>
+    );
+  }
 };
 CommonComponents.propTypes = {
   entity: React.PropTypes.object

--- a/src/components/attributes/Component.js
+++ b/src/components/attributes/Component.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import AttributeRow from './AttributeRow';
 import Collapsible from '../Collapsible';
+var Clipboard = require('clipboard');
 
 function isSingleProperty (schema) {
   if ('type' in schema) {
@@ -17,14 +18,71 @@ export default class Component extends React.Component {
     name: React.PropTypes.string
   };
 
+  constructor (props) {
+    super(props);
+    this.state = {
+      entity: this.props.entity,
+      name: this.props.name
+    };
+  }
+
+  componentWillReceiveProps(newProps) {
+    if (this.state.entity !== newProps.entity) {
+      this.setState({entity: newProps.entity});
+    }
+    if (this.state.name !== newProps.name) {
+      this.setState({name: newProps.name});
+    }
+  }
+
   deleteComponent = event => {
     event.stopPropagation();
-    this.props.entity.removeAttribute(this.props.name);
+    if (confirm('Do you really want to delete component `' + this.props.name + '`?')) {
+      this.props.entity.removeAttribute(this.props.name);
+    }
   }
 
   resetComponent = event => {
     event.stopPropagation();
-    this.props.entity.setAttribute(this.props.name, {});
+    if (confirm('Do you really want to restore the default values for the component `' + this.props.name + '`?')) {
+      this.props.entity.setAttribute(this.props.name, {});
+    }
+  }
+  componentDidMount() {
+    var self = this;
+    var clipboard = new Clipboard('[data-action="copy-component-to-clipboard"]', {
+      text: function (trigger) {
+        function copyToClipboard(entity, componentName) {
+          function getModifiedAttributes(entity, componentName)  {
+            var data = entity.components[componentName].data;
+            var defaultData = entity.components[componentName].schema;
+            var diff = {};
+            for (var key in data) {
+              // @todo Some parameters could be null and '' like mergeTo
+              if (data[key] !== defaultData[key].default) {
+                diff[key] = data[key];
+              }
+            }
+            return diff;
+          }
+
+          function getAttributesFromJSON(data) {
+            return Object.keys(data).map(function(k) {
+                return k + ': ' + data[k]
+            }).join('; ')
+          }
+
+          var diff = getModifiedAttributes(entity, componentName);
+          return getAttributesFromJSON(diff);
+        }
+
+        var componentName = trigger.getAttribute('data-component').toLowerCase();
+        return copyToClipboard(self.state.entity, componentName);
+      }
+    });
+    clipboard.on('error', function(e) {
+        console.error('Error while copying to clipboard:', e.action, e.trigger);
+    });
   }
 
   render () {
@@ -60,12 +118,14 @@ export default class Component extends React.Component {
       <Collapsible>
         <div className='collapsible-header'>
           <span>{componentName} <span className='subcomponent'>{subComponentName}</span></span>
-          <div className='dropdown menu'>
-            <div className='dropdown-content'>
-              <a href='#' onClick={this.deleteComponent}>Delete</a>
-              <a href='#' onClick={this.resetComponent}>Reset to default</a>
-              <a href='#' className='disabled'>Copy to clipboard</a>
-            </div>
+          <div>
+            <a href="#" title="Copy to clipboard" data-action="copy-component-to-clipboard"
+              data-component={subComponentName || componentName}
+              className="button fa fa-clipboard" onClick={event => event.stopPropagation()}></a>
+            <a href="#" title="Reset to default" className="button fa fa-undo"
+              onClick={this.resetComponent}></a>
+            <a href="#" title="Delete component" className="button fa fa-trash-o"
+              onClick={this.deleteComponent}></a>
           </div>
         </div>
         <div className='collapsible-content'>{attributeRows}</div>

--- a/src/css/dark.css
+++ b/src/css/dark.css
@@ -320,6 +320,10 @@ div.vec3 {
   width: 50px;
 }
 
+.collapsible-header {
+  display: flex;
+  justify-content: space-between;
+}
 .collapsible-header span {
   float: left;
   text-transform: uppercase;
@@ -347,7 +351,7 @@ div.vec3 {
   text-align: right;
 }
 
-.collapsible .static .button {
+.collapsible .static .collapse-button {
   margin-top: 2px;
   width: 0;
   height: 0;
@@ -357,11 +361,11 @@ div.vec3 {
   border-right: 5px solid transparent;
 }
 
-.collapsible.collapsed .static .button {
+.collapsible.collapsed .static .collapse-button {
   border-left-color: #1faaf2;
 }
 
-.collapsible:not(.collapsed) .static .button {
+.collapsible:not(.collapsed) .static .collapse-button {
   border-top-color: #1faaf2;
 }
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -42,7 +42,7 @@ textarea, input { outline: none; } /* osx */
 		margin: 0;
 	}
 
-	.collapsible .static .button {
+	.collapsible .static .collapse-button {
 		float: left;
 		margin-right: 6px;
 		width: 0;
@@ -50,12 +50,12 @@ textarea, input { outline: none; } /* osx */
 		border: 6px solid transparent;
 	}
 
-	.collapsible.collapsed .static .button {
+	.collapsible.collapsed .static .collapse-button {
 		margin-top: 2px;
 		border-left-color: #1faaf2;
 	}
 
-	.collapsible:not(.collapsed) .static .button {
+	.collapsible:not(.collapsed) .static .collapse-button {
 		margin-top: 6px;
 		border-top-color: #1faaf2;
 	}


### PR DESCRIPTION
Related to:
https://github.com/aframevr/aframe-editor/issues/10
https://github.com/aframevr/aframe-editor/issues/56

Moved the icons from the threedots contextual menu to the right of the component title. (The icons' style it's just a POC, feel free to propose how to improve it! :))

Added copy to clipboard:
- **entity level** -> HTML: eg: 

``` xml
<a-entity camera="active:false" look-controls="" wasd-controls="" position="" rotation="0 0 0" scale="" visible="">
  <a-entity visible="true" position="0 0 -2" geometry="primitive: ring; radiusOuter: 0.016; radiusInner: 0.01" material="color: #ff9; shader: flat; transparent: true; opacity: 0.5" scale="2 2 2" raycaster="" rotation="">
  </a-entity>
</a-entity>
```
- **component level** -> attribute style. eg: `html mergeTo: null; primitive: cylinder; height: 0.2; radius: 12`

<img width="948" alt="screenshot 2016-07-10 01 20 39" src="https://cloud.githubusercontent.com/assets/782511/16710797/8dc6fe06-463c-11e6-9809-43cf5d6be58e.png">
