### PR TITLE
Copy component to clipboard

### DIFF
--- a/src/actions/component.js
+++ b/src/actions/component.js
@@ -1,0 +1,37 @@
+/**
+ * Get the list of modified properties
+ * @param  {Element} entity        Entity where the component belongs
+ * @param  {string} componentName Component name
+ * @return {object}               List of modified properties with their value
+ */
+function getModifiedProperties (entity, componentName) {
+  var data = entity.components[componentName].data;
+  var defaultData = entity.components[componentName].schema;
+  var diff = {};
+  for (var key in data) {
+    var defaultValue = defaultData[key].default;
+    var currentValue = data[key];
+
+    // Some parameters could be null and '' like mergeTo
+    if (!(isEmpty(currentValue) && isEmpty(defaultValue)) &&
+      currentValue !== defaultValue) {
+      diff[key] = data[key];
+    }
+  }
+  return diff;
+}
+
+/**
+ * [getClipboardRepresentation description]
+ * @param  {[type]} entity        [description]
+ * @param  {[type]} componentName [description]
+ * @return {[type]}               [description]
+ */
+export function getClipboardRepresentation (entity, componentName) {
+  var diff = getModifiedProperties(entity, componentName);
+  return AFRAME.utils.styleParser.stringify(diff);
+}
+
+function isEmpty (string) {
+  return string === null || string === '';
+}

--- a/src/components/components/Component.js
+++ b/src/components/components/Component.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import PropertyRow from './PropertyRow';
 import Collapsible from '../Collapsible';
+import Clipboard from 'clipboard';
+import {getClipboardRepresentation} from '../../actions/component';
 
 const isSingleProperty = AFRAME.schema.isSingleProperty;
 
@@ -21,6 +23,18 @@ export default class Component extends React.Component {
       entity: this.props.entity,
       name: this.props.name
     };
+  }
+
+  componentDidMount () {
+    var clipboard = new Clipboard('[data-action="copy-component-to-clipboard"]', {
+      text: trigger => {
+        var componentName = trigger.getAttribute('data-component').toLowerCase();
+        return getClipboardRepresentation(this.state.entity, componentName);
+      }
+    });
+    clipboard.on('error', e => {
+      // @todo Show the error in the UI
+    });
   }
 
   componentWillReceiveProps (newProps) {
@@ -78,7 +92,12 @@ export default class Component extends React.Component {
             {subComponentName || componentName}
           </span>
           <div>
-            <a href='#' title='Remove component' className='flat-button'
+            <a title='Copy to clipboard' data-action='copy-component-to-clipboard'
+              data-component={subComponentName || componentName}
+              className='flat-button' onClick={event => event.stopPropagation()}>
+              copy html
+            </a>
+            <a title='Remove component' className='flat-button'
               onClick={this.removeComponent}>remove</a>
           </div>
         </div>


### PR DESCRIPTION
Added copy component data to clipboard:
<img width="292" alt="screenshot 2016-07-12 02 39 12" src="https://cloud.githubusercontent.com/assets/782511/16751438/d7bb412c-47d9-11e6-8e66-74e6502bccf7.png">

It just copy the values modified from the default schema. For the previous image the string copied to the clipboard is:
`color: #fafafa; metalness: 0.2; repeat: 50 20; roughness: 0.1; src: #floorImg`
