### PR TITLE
Export scene name based on ID or slugify url. Fixes #22

### DIFF
--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -1,7 +1,7 @@
-var React = require('react');
-var Clipboard = require('clipboard');
-var Exporter = require('../../lib/exporter.js');
-var Events = require('../../lib/Events.js');
+import React from 'react';
+import Clipboard from 'clipboard';
+import Events from '../../lib/Events.js';
+import {getSceneName, generateHtml} from '../../lib/exporter';
 
 var primitivesDefinitions = {
   'Entity': {group: 'entities', element: 'a-entity', components: {}},
@@ -83,7 +83,7 @@ export class MenuWidget extends React.Component {
   componentDidMount() {
     var clipboard = new Clipboard('[data-action="copy-to-clipboard"]', {
       text: function (trigger) {
-        return Exporter.generateHtml();
+        return generateHtml();
       }
     });
     clipboard.on('error', function(e) {
@@ -113,7 +113,8 @@ export class MenuWidget extends React.Component {
       save(new Blob([ text ], { type: 'text/plain' }), filename);
     }
 
-    saveString(Exporter.generateHtml(), 'ascene.html');
+    var sceneName = getSceneName(document.querySelector('a-scene'));
+    saveString(generateHtml(), sceneName);
   }
 
   render() {

--- a/src/lib/exporter.js
+++ b/src/lib/exporter.js
@@ -1,41 +1,72 @@
-module.exports = {
-  parser: new window.DOMParser(),
-  xmlToString: function (xmlData) {
-    var xmlString;
-    // IE
-    if (window.ActiveXObject) {
-      xmlString = xmlData.xml;
-    } else {
-      // Mozilla, Firefox, Opera, etc.
-      xmlString = (new window.XMLSerializer()).serializeToString(xmlData);
-    }
-    return xmlString;
-  },
-  generateHtml: function () {
-    var xmlDoc = this.parser.parseFromString(document.documentElement.innerHTML, 'text/html');
+/**
+ * Get scene name
+ * @param  {Element} scene Scene element
+ * @return {string}       Scene ID or slugify from the current path
+ */
+export function getSceneName (scene) {
+  return scene.id || slugify(window.location.host + window.location.pathname);
+}
 
-    // Remove all the components that are being injected by aframe-editor or aframe
-    // @todo Use custom class to prevent this hack
-    var elementsToRemove = xmlDoc.querySelectorAll([
-      // Injected by the editor
-      '[data-aframe-editor]',
-      'script[src$="aframe-editor.js"]',
-      'style[type="text/css"]',
-      // Injected by aframe
-      '.a-enter-vr',
-      '.a-orientation-modal',
-      '.a-canvas',
-      '.a-enter-vr-button',
-      'style[data-href$="aframe.css"]',
-      // Injected by stats
-      '.rs-base',
-      'style[data-href$="rStats.css"]'
-    ].join(','));
-    for (var i = 0; i < elementsToRemove.length; i++) {
-      var el = elementsToRemove[i];
-      el.parentNode.removeChild(el);
-    }
+/**
+ * Slugify the string removing non-word chars and spaces
+ * @param  {string} text String to slugify
+ * @return {string}      Slugified string
+ */
+function slugify(text) {
+  return text.toString().toLowerCase()
+    .replace(/\s+/g, '-')           // Replace spaces with -
+    .replace(/[^\w\-]+/g, '-')      // Replace all non-word chars with -
+    .replace(/\-\-+/g, '-')         // Replace multiple - with single -
+    .replace(/^-+/, '')             // Trim - from start of text
+    .replace(/-+$/, '');            // Trim - from end of text
+}
 
-    return this.xmlToString(xmlDoc);
+/**
+ * Generate a filtered stringify HTML from the current page
+ * @return {string} String that contains the filtered HTML of the current page
+ */
+export function generateHtml() {
+  var parser = new window.DOMParser();
+  var xmlDoc = parser.parseFromString(document.documentElement.innerHTML, 'text/html');
+
+  // Remove all the components that are being injected by aframe-editor or aframe
+  // @todo Use custom class to prevent this hack
+  var elementsToRemove = xmlDoc.querySelectorAll([
+    // Injected by the editor
+    '[data-aframe-editor]',
+    'script[src$="aframe-editor.js"]',
+    'style[type="text/css"]',
+    // Injected by aframe
+    '.a-enter-vr',
+    '.a-orientation-modal',
+    '.a-canvas',
+    '.a-enter-vr-button',
+    'style[data-href$="aframe.css"]',
+    // Injected by stats
+    '.rs-base',
+    'style[data-href$="rStats.css"]'
+  ].join(','));
+  for (var i = 0; i < elementsToRemove.length; i++) {
+    var el = elementsToRemove[i];
+    el.parentNode.removeChild(el);
   }
-};
+
+  return xmlToString(xmlDoc);
+}
+
+/**
+ * Returns the string representation of a XML
+ * @param  {Document} xmlData XML to stringify
+ * @return {string}         String representation of the XML document
+ */
+function xmlToString(xmlData) {
+  var xmlString;
+  // IE
+  if (window.ActiveXObject) {
+    xmlString = xmlData.xml;
+  } else {
+    // Mozilla, Firefox, Opera, etc.
+    xmlString = (new window.XMLSerializer()).serializeToString(xmlData);
+  }
+  return xmlString;
+}


### PR DESCRIPTION
Instead of use the current `ascene.html` filename, the editor will take the `id` of `a-scene` if exist or it will slugifly `window.location.host + window.location.pathname` as @cvan proposed on https://github.com/aframevr/aframe-editor/issues/22
