### PR TITLE
Set pointer cursor for enter/exit button

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -97,6 +97,7 @@ textarea, input { outline: none; } /* osx */
 	padding: 6px 20px;
 	color: #fff;
 	text-decoration: none;
+	cursor: pointer;
 }
 
 .toggle-edit:hover {


### PR DESCRIPTION
Minor annoyance but the text cursor is showing over the enter/exit button.  Pointer makes it more apparent it's meant to be clicked.
