### PR TITLE
Fixes error while selecting a-scene in scenegraph

### DIFF
--- a/src/components/components/Component.js
+++ b/src/components/components/Component.js
@@ -71,7 +71,7 @@ export default class Component extends React.Component {
     const componentData = this.props.component;
 
     if (isSingleProperty(componentData.schema)) {
-      const componentName = componentName.toLowerCase();
+      const componentName = this.props.name;
       const schema = AFRAME.components[componentName].schema;
       return (
         <PropertyRow key={componentName} name={componentName} schema={schema}
@@ -89,7 +89,7 @@ export default class Component extends React.Component {
   }
 
   render () {
-    let componentName = this.props.name.toUpperCase();
+    let componentName = this.props.name;
     let subComponentName = '';
     if (componentName.indexOf('__') !== -1) {
       subComponentName = componentName;
@@ -102,7 +102,7 @@ export default class Component extends React.Component {
       <Collapsible key={this.state.key}>
         <div className='collapsible-header'>
           <span className='component-title' title={subComponentName || componentName}>
-            {subComponentName || componentName} {componentHelp}
+            <span>{subComponentName || componentName}</span> {componentHelp}
           </span>
           <div>
             <a title='Copy to clipboard' data-action='copy-component-to-clipboard'

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -451,11 +451,13 @@ div.vec3 {
   display: flex;
   justify-content: space-between;
 }
-.collapsible-header span {
+
+.component-title span {
   float: left;
-  max-width: 180px;
+  max-width: 110px;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
   text-transform: uppercase;
 }
 

--- a/src/lib/viewport/index.js
+++ b/src/lib/viewport/index.js
@@ -287,7 +287,7 @@ function Viewport (inspector) {
   Events.on('objectSelected', function (object) {
     selectionBox.visible = false;
     transformControls.detach();
-    if (object !== null) {
+    if (object && object.el) {
       if (object.el.getObject3D('mesh')) {
         selectionBox.update(object);
         selectionBox.visible = true;


### PR DESCRIPTION
Fixes an error while selecting a-scene node in the scenegraph. I also fixed the width of the component's name as it wasn't show correctly the ellipsis on overflow.
