### PR TITLE
Add docs links for common components. Fixes #212

### DIFF
--- a/src/actions/component.js
+++ b/src/actions/component.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 /**
  * Get the list of modified properties
  * @param  {Element} entity        Entity where the component belongs
@@ -30,6 +32,35 @@ function getModifiedProperties (entity, componentName) {
 export function getClipboardRepresentation (entity, componentName) {
   var diff = getModifiedProperties(entity, componentName);
   return AFRAME.utils.styleParser.stringify(diff);
+}
+
+/**
+ * Get the component docs link
+ * @param  {string} componentName Component's name
+ * @return {string}               URL to the documentation
+ */
+export function getComponentDocsUrl (componentName) {
+  if (AFRAME.components[componentName]) {
+    // Returns link from the core components
+    return 'https://aframe.io/docs/' + AFRAME.version + '/components/' +
+      (componentName === 'camera' ? '' : componentName.toLowerCase() + '.html');
+  }
+  return null;
+}
+
+/**
+ * Get component documentation html link
+ * @param  {string} componentName Component's name
+ * @return {string}               Html icon link to the documentation
+ */
+export function getComponentDocsHtmlLink (componentName) {
+  let url = getComponentDocsUrl(componentName);
+  if (url) {
+    return <a title='Help' className='button fa fa-question-circle'
+      target='_blank' onClick={event => event.stopPropagation()}
+      href={url}></a>;
+  }
+  return '';
 }
 
 function isEmpty (string) {

--- a/src/components/components/CommonComponents.js
+++ b/src/components/components/CommonComponents.js
@@ -42,8 +42,8 @@ const CommonComponents = props => {
             const schema = AFRAME.components[key].schema;
             return (
               <PropertyRow onChange={updateEntity} key={key} name={key}
-                schema={schema} data={componentData.data} componentname={key}
-                entity={props.entity}/>
+                show_help={true} schema={schema} data={componentData.data}
+                componentname={key} entity={props.entity}/>
             );
           })
         }

--- a/src/components/components/Component.js
+++ b/src/components/components/Component.js
@@ -3,7 +3,7 @@ import React from 'react';
 import PropertyRow from './PropertyRow';
 import Collapsible from '../Collapsible';
 import Clipboard from 'clipboard';
-import {getClipboardRepresentation} from '../../actions/component';
+import {getClipboardRepresentation, getComponentDocsHtmlLink} from '../../actions/component';
 
 const isSingleProperty = AFRAME.schema.isSingleProperty;
 
@@ -86,13 +86,7 @@ export default class Component extends React.Component {
       componentName = componentName.substr(0, componentName.indexOf('__'));
     }
 
-    const link = getComponentDocsLink(componentName.toLowerCase());
-    let componentHelp = '';
-    if (link) {
-      componentHelp = <a title='Help' className='button fa fa-question-circle'
-        target='_blank' onClick={event => event.stopPropagation()}
-        href={link}></a>;
-    }
+    const componentHelp = getComponentDocsHtmlLink(componentName.toLowerCase());
 
     return (
       <Collapsible>
@@ -116,16 +110,4 @@ export default class Component extends React.Component {
       </Collapsible>
     );
   }
-}
-
-/**
- * Get the component docs link
- */
-function getComponentDocsLink (componentName) {
-  if (AFRAME.components[componentName]) {
-    // Returns link from the core components
-    return 'https://aframe.io/docs/' + AFRAME.version + '/components/' +
-      (componentName === 'camera' ? '' : componentName.toLowerCase() + '.html');
-  }
-  return null;
 }

--- a/src/components/components/PropertyRow.js
+++ b/src/components/components/PropertyRow.js
@@ -9,6 +9,7 @@ import SelectWidget from '../widgets/SelectWidget';
 import TextureWidget from '../widgets/TextureWidget';
 import Vec3Widget from '../widgets/Vec3Widget';
 import {updateEntity} from '../../actions/entity';
+import {getComponentDocsHtmlLink} from '../../actions/component';
 
 export default class PropertyRow extends React.Component {
   static propTypes = {
@@ -80,9 +81,10 @@ export default class PropertyRow extends React.Component {
   render () {
     const props = this.props;
     const title = 'type: ' + props.schema.type + ' value: ' + JSON.stringify(props.data);
+    const help_link = props.show_help ? getComponentDocsHtmlLink(props.name) : '';
     return (
       <div className='row'>
-        <label htmlFor={this.id} className='text' title={title}>{props.name}</label>
+        <label htmlFor={this.id} className='text' title={title}>{props.name}{help_link}</label>
         {this.getWidget(props.schema.type)}
       </div>
     );


### PR DESCRIPTION
Added help icon button next to the common components (position, rotation, scale, visible)
<img width="329" alt="screenshot 2016-08-02 23 45 56" src="https://cloud.githubusercontent.com/assets/782511/17346527/5e84c8bc-590b-11e6-9a19-8bcf139942ca.png">
