### PR TITLE
Using cross-env to set env variables in a cross platform way

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "An inspector for A-Frame scenes.",
   "main": "index.js",
   "scripts": {
-    "build": "NODE_ENV=production webpack --progress --colors -p",
+    "build": "cross-env NODE_ENV=production webpack --progress --colors -p",
     "ghpages": "npm run preghpages && node ./scripts/gh-pages",
     "lint": "npm run lintfile src/",
     "lintfile": "node --harmony node_modules/.bin/eslint",
     "preghpages": "npm run build && shx rm -rf gh-pages && shx mkdir gh-pages && shx cp -r build example index.html gh-pages && shx sed -i http://localhost:3333 .. gh-pages/example/index.html",
-    "start": "NODE_ENV=dev webpack-dev-server --progress --colors --hot -d --open"
+    "start": "cross-env NODE_ENV=dev webpack-dev-server --progress --colors --hot -d --open"
   },
   "repository": "aframevr/aframe-inspector",
   "license": "MIT",
@@ -28,6 +28,7 @@
     "babel-plugin-transform-class-properties": "^6.10.2",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
+    "cross-env": "^2.0.0",
     "css-loader": "^0.23.1",
     "eslint": "^2.9.x",
     "eslint-config-standard": "^5.3.1",


### PR DESCRIPTION
The current `build` and `start` commands are specific to UNIX shells. I replaced them to make them work cross platform. You can either ping me if you modify them next time or make sure you test on Windows.
