### PR TITLE
Fix 'Can only update a mounted or mounting component'

### DIFF
--- a/src/components/components/CommonComponents.js
+++ b/src/components/components/CommonComponents.js
@@ -24,17 +24,12 @@ export class CommonComponents extends React.Component {
 
   constructor (props) {
     super(props);
-    this.state = {
-      key: Math.random() // Used to trigger render() on state changes instead of calling forceUpdate()
-    };
   }
 
   componentDidMount () {
     Events.on('selectedEntityComponentChanged', detail => {
       if (DEFAULT_COMPONENTS.indexOf(detail.name) !== -1) {
-        // Instead of calling forceUpdate() we update the state with a random
-        // key so it will trigger the render() function
-        this.setState({ key: Math.random() });
+        this.forceUpdate();
       }
     });
   }
@@ -59,7 +54,7 @@ export class CommonComponents extends React.Component {
     const entity = this.props.entity;
     if (!entity) { return <div></div>; }
     return (
-      <Collapsible key={this.state.key}>
+      <Collapsible>
         <div className='collapsible-header'>
           <span>Common</span>
         </div>

--- a/src/components/components/Component.js
+++ b/src/components/components/Component.js
@@ -22,8 +22,7 @@ export default class Component extends React.Component {
     super(props);
     this.state = {
       entity: this.props.entity,
-      name: this.props.name,
-      key: Math.random() // Used to trigger render() on state changes instead of calling forceUpdate()
+      name: this.props.name
     };
   }
 
@@ -40,9 +39,7 @@ export default class Component extends React.Component {
 
     Events.on('selectedEntityComponentChanged', detail => {
       if (detail.name === this.props.name) {
-        // Instead of calling forceUpdate() we update the state with a random
-        // key so it will trigger the render() function
-        this.setState({ key: Math.random() });
+        this.forceUpdate();
       }
     });
   }
@@ -99,7 +96,7 @@ export default class Component extends React.Component {
     const componentHelp = getComponentDocsHtmlLink(componentName.toLowerCase());
 
     return (
-      <Collapsible key={this.state.key}>
+      <Collapsible>
         <div className='collapsible-header'>
           <span className='component-title' title={subComponentName || componentName}>
             <span>{subComponentName || componentName}</span> {componentHelp}


### PR DESCRIPTION
With the latest changes trying to prevent `forceUpdate()` on `componentchanged` I generated a random key for the component, but this is generating the component to regenerate itself and some update events from the widgets are conflicting with the mounting of the component as is stated on the console:

```
warning.js:44 Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the undefined component.
```

I've changed it back to `forceUpdate()` to get rid of this until we'll find a better solution. /cc @ngokevin 
