### PR TITLE
Fixes #273 Inspector can't change scene background color

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -413,10 +413,13 @@ input[type=color]::-moz-focus-inner {
 }
 
 body {
-  background-color: #191919;
   font-family: 'Roboto', sans-serif;
   font-size: 12px;
   color: #fff;
+}
+
+body.editor-opened {
+  background-color: #191919;
 }
 
 .components {

--- a/src/lib/inspector.js
+++ b/src/lib/inspector.js
@@ -249,12 +249,14 @@ Inspector.prototype = {
     this.opened = true;
     Events.emit('inspectorModeChanged', true);
     this.sceneEl.pause();
+    document.body.classList.add('editor-opened');
   },
 
   close: function () {
     this.opened = false;
     Events.emit('inspectorModeChanged', false);
     this.sceneEl.play();
+    document.body.classList.remove('editor-opened');
   // @todo Removelisteners
   },
 


### PR DESCRIPTION
@dmarcos Regarding https://github.com/aframevr/aframe-inspector/issues/273 this will just inject a CSS class to the body when the inspector is opened.
Right how it will change the background color when the inspector is opened to: `#191919`, should I maintain the scene's background color even if the inspector is opened?
