### PR TITLE
Add components icons title with parameters and hover color

### DIFF
--- a/src/components/scenegraph/SceneGraph.js
+++ b/src/components/scenegraph/SceneGraph.js
@@ -97,9 +97,16 @@ export default class SceneGraph extends React.Component {
         if (!child.dataset.isInspector && child.isEntity && !child.isInspector) {
           let extra = '';
 
-          for (let icon in ICONS) {
-            if (child.components && child.components[icon]) {
-              extra += ' <i class="fa ' + ICONS[icon] + '"></i>';
+          for (let componentName in ICONS) {
+            if (child.components && child.components[componentName]) {
+              let properties = child.getAttribute(componentName);
+              const titles = Object.keys(properties)
+                .sort()
+                .map(property => {
+                  return ' - ' + property + ': ' + properties[property];
+                });
+              let componentTitle = componentName + (titles.length ? '\n' + titles.join('\n') : '');
+              extra += ' <i class="component fa ' + ICONS[componentName] + '" title="' + componentTitle + '"></i>';
             }
           }
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -955,6 +955,15 @@ code, pre {
   color: #fff;
 }
 
+.outliner .option .component:hover {
+  color: #1faaf2;
+}
+
+.outliner .option.active .component:hover {
+  color: #1888c1;
+}
+
+
 .outliner .option .icons {
   display: none;
   margin: 0 3px 0 10px;


### PR DESCRIPTION
Added style (color) when mouse is over the component's icons, and added a title to the icon with the component's name and its properties values (non-default ones) for quick review.
<img width="194" alt="screenshot 2016-08-17 00 33 37" src="https://cloud.githubusercontent.com/assets/782511/17718446/2e8997be-6414-11e6-9e42-68526be04651.png">
