### PR TITLE
Fixes #34 Introduce shortcut to toggle the inspector

### DIFF
--- a/src/lib/inspector.js
+++ b/src/lib/inspector.js
@@ -172,6 +172,19 @@ Inspector.prototype = {
     }
   },
   initEvents: function () {
+    window.addEventListener('keydown', evt => {
+      // Alt + Ctrl + i
+      var shortcutPressed = evt.keyCode === 73 && evt.ctrlKey && evt.altKey;
+      var escape = evt.keyCode === 27;
+      if (escape) {
+        this.close();
+        return;
+      }
+      if (shortcutPressed) {
+        this.toggle();
+      }
+    });
+
     Events.on('entitySelected', entity => {
       this.selectEntity(entity, false);
     });
@@ -250,6 +263,16 @@ Inspector.prototype = {
   addEntity: function (entity) {
     this.addObject(entity.object3D);
     this.selectEntity(entity);
+  },
+  /**
+   * Toggle the editor
+   */
+  toggle: function () {
+    if (this.opened) {
+      this.close();
+    } else {
+      this.open();
+    }
   },
   /**
    * Open the editor UI


### PR DESCRIPTION
Following the AFRAME PR https://github.com/aframevr/aframe/pull/1599 I added the same functionality to toggle the inspector using `ctrl+alt+i` or `esc` to exit the inspector.
