### PR TITLE
Add basic shortcuts

### DIFF
--- a/src/actions/entity.js
+++ b/src/actions/entity.js
@@ -1,4 +1,3 @@
-var INSPECTOR = require('../lib/inspector.js');
 var Events = require('../lib/Events.js');
 var components = AFRAME.components;
 var isSingleProperty = AFRAME.schema.isSingleProperty;
@@ -49,9 +48,9 @@ export function removeEntity (entity, force) {
   if (entity) {
     if (force === true || confirm('Do you really want to remove entity `' + (entity.id || entity.tagName) + '`?')) {
       var closest = findClosestEntity(entity);
-      INSPECTOR.removeObject(entity.object3D);
+      AFRAME.INSPECTOR.removeObject(entity.object3D);
       entity.parentNode.removeChild(entity);
-      INSPECTOR.selectEntity(closest);
+      AFRAME.INSPECTOR.selectEntity(closest);
     }
   }
 }
@@ -86,7 +85,9 @@ function findClosestEntity (entity) {
  * @param  {boolean} force (Optional) If true it won't ask for confirmation
  */
 export function removeSelectedEntity (force) {
-  removeEntity(INSPECTOR.selectedEntity);
+  if (AFRAME.INSPECTOR.selectedEntity) {
+    removeEntity(AFRAME.INSPECTOR.selectedEntity);
+  }
 }
 
 /**
@@ -105,7 +106,7 @@ function insertAfter (newNode, referenceNode) {
 export function cloneEntity (entity) {
   var copy = entity.cloneNode(true);
   copy.addEventListener('loaded', function (e) {
-    INSPECTOR.selectEntity(copy);
+    AFRAME.INSPECTOR.selectEntity(copy);
   });
 
   // Get a valid unique ID for the entity
@@ -114,7 +115,7 @@ export function cloneEntity (entity) {
   }
   copy.addEventListener('loaded', function () {
     Events.emit('domModified');
-    INSPECTOR.selectEntity(copy);
+    AFRAME.INSPECTOR.selectEntity(copy);
   });
   insertAfter(copy, entity);
 }
@@ -123,7 +124,9 @@ export function cloneEntity (entity) {
  * Clone the selected entity
  */
 export function cloneSelectedEntity () {
-  cloneEntity(INSPECTOR.selectedEntity);
+  if (AFRAME.INSPECTOR.selectedEntity) {
+    cloneEntity(AFRAME.INSPECTOR.selectedEntity);
+  }
 }
 
 /**

--- a/src/components/ToolBar.js
+++ b/src/components/ToolBar.js
@@ -16,6 +16,11 @@ export default class Toolbar extends React.Component {
       localSpace: false
     };
   }
+  componentDidMount () {
+    Events.on('transformModeChanged', (mode) => {
+      this.setState({selectedTransform: mode});
+    });
+  }
 
   changeTransformMode = mode => {
     this.setState({selectedTransform: mode});

--- a/src/lib/inspector.js
+++ b/src/lib/inspector.js
@@ -2,6 +2,7 @@ var Events = require('./Events');
 var Viewport = require('./viewport/index.js');
 var ComponentLoader = require('./componentloader.js');
 var ShaderLoader = require('./shaderloader.js');
+var Shortcuts = require('./shortcuts.js');
 
 function Inspector () {
   this.opened = false;
@@ -163,13 +164,9 @@ Inspector.prototype = {
   },
   initEvents: function () {
     window.addEventListener('keydown', evt => {
-      // Alt + Ctrl + i
+
+      // Alt + Ctrl + i: Shorcut to toggle the inspector
       var shortcutPressed = evt.keyCode === 73 && evt.ctrlKey && evt.altKey;
-      var escape = evt.keyCode === 27;
-      if (escape) {
-        this.close();
-        return;
-      }
       if (shortcutPressed) {
         this.toggle();
       }
@@ -278,6 +275,7 @@ Inspector.prototype = {
     }
     document.body.classList.add('aframe-inspector-opened');
     this.sceneEl.resize();
+    Shortcuts.enable();
   },
   /**
    * Closes the editor and gives the control back to the scene
@@ -293,6 +291,7 @@ Inspector.prototype = {
     }
     document.body.classList.remove('aframe-inspector-opened');
     this.sceneEl.resize();
+    Shortcuts.disable();
   },
   addObject: function (object) {
     var scope = this;

--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -1,0 +1,57 @@
+/* globals AFRAME */
+var Events = require('./Events');
+var shouldCaptureKeyEvent = AFRAME.utils.shouldCaptureKeyEvent;
+import {removeSelectedEntity, cloneSelectedEntity} from '../actions/entity';
+
+module.exports = {
+  onKeyUp: function (event) {
+    if (!shouldCaptureKeyEvent(event)) { return; }
+
+    // esc: close inspector
+    if (event.keyCode === 27) {
+      AFRAME.INSPECTOR.close();
+      return;
+    }
+
+    // w: translate
+    if (event.keyCode === 87) {
+      Events.emit('transformModeChanged', 'translate');
+    }
+
+    // e: rotate
+    if (event.keyCode === 69) {
+      Events.emit('transformModeChanged', 'rotate');
+    }
+
+    // r: scale
+    if (event.keyCode === 82) {
+      Events.emit('transformModeChanged', 'scale');
+    }
+
+    // g: toggle grid
+    if (event.keyCode === 71) {
+      Events.emit('toggleGrid');
+    }
+
+    // n: new entity
+    if (event.keyCode === 78) {
+      Events.emit('createNewEntity', {element: 'a-entity', components: {}});
+    }
+
+    // backspace & supr: remove selected entity
+    if (event.keyCode === 8 || event.keyCode === 46) {
+      removeSelectedEntity();
+    }
+
+    // d: clone selected entity
+    if (event.keyCode === 68) {
+      cloneSelectedEntity();
+    }
+  },
+  enable: function () {
+    window.addEventListener('keyup', this.onKeyUp, false);
+  },
+  disable: function () {
+    window.removeEventListener('keyup', this.onKeyUp);
+  },
+};

--- a/src/lib/vendor/threejs/TransformControls.js
+++ b/src/lib/vendor/threejs/TransformControls.js
@@ -774,6 +774,12 @@
 
 		};
 
+		this.toggleSpace = function () {
+
+			this.setSpace(scope.space === 'local' ? 'world' : 'local');
+
+		};
+
 		this.setSpace = function ( space ) {
 
 			scope.space = space;

--- a/src/lib/viewport/index.js
+++ b/src/lib/viewport/index.js
@@ -361,8 +361,11 @@ function Viewport (inspector) {
     camera.updateProjectionMatrix();
     // renderer.setSize(container.dom.offsetWidth, container.dom.offsetHeight);
   });
-  Events.on('showGridChanged', showGrid => {
+  Events.on('gridVisibilityChanged', showGrid => {
     grid.visible = showGrid;
+  });
+  Events.on('toggleGrid', () => {
+    grid.visible = !grid.visible;
   });
 
   Events.on('inspectorModeChanged', active => {


### PR DESCRIPTION
Based on https://github.com/aframevr/aframe-inspector/issues/298 I added some shortcuts:
- **`w,e,r`**
  Switch to Translate/Rotate/Scale modes
- **`d`**
  Duplicate/clone current selection
- **`g`** 
  Toggle grid visibility
- **`n`**
  Add new entity
- **`supr / backspace`** 
  Delete current selection
- **`ctrl+alt+i`** 
  Switch Edit and VR modes. 
- **`Esc`** for exiting edit mode (current behaviour)

![shortcuts](https://cloud.githubusercontent.com/assets/782511/17783216/504ed1ca-6577-11e6-94bd-b6e058b21f3a.gif)
