### PR TITLE
Fix circular dependencies for INSPECTOR

### DIFF
--- a/src/actions/entity.js
+++ b/src/actions/entity.js
@@ -2,7 +2,7 @@ var Events = require('../lib/Events.js');
 var components = AFRAME.components;
 var isSingleProperty = AFRAME.schema.isSingleProperty;
 
-import {DEFAULT_COMPONENTS} from '../components/components/CommonComponents';
+import DEFAULT_COMPONENTS from '../components/components/DefaultComponents';
 
 /**
  * Update a component.

--- a/src/components/components/CommonComponents.js
+++ b/src/components/components/CommonComponents.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {InputWidget} from '../widgets';
+import DEFAULT_COMPONENTS from './DefaultComponents';
 import PropertyRow from './PropertyRow';
 import Collapsible from '../Collapsible';
 import Mixins from './Mixins';
@@ -14,9 +15,7 @@ function changeId (entity, componentName, propertyName, value) {
   }
 }
 
-export const DEFAULT_COMPONENTS = ['visible', 'position', 'scale', 'rotation'];
-
-export class CommonComponents extends React.Component {
+export default class CommonComponents extends React.Component {
   static propTypes = {
     entity: React.PropTypes.object
   };

--- a/src/components/components/ComponentsContainer.js
+++ b/src/components/components/ComponentsContainer.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import AddComponent from './AddComponent';
 import Component from './Component';
-import {CommonComponents, DEFAULT_COMPONENTS} from './CommonComponents';
+import CommonComponents from './CommonComponents';
+import DEFAULT_COMPONENTS from './DefaultComponents';
 
 export default class ComponentsContainer extends React.Component {
   static propTypes = {

--- a/src/components/components/DefaultComponents.js
+++ b/src/components/components/DefaultComponents.js
@@ -1,0 +1,1 @@
+export default ['visible', 'position', 'scale', 'rotation'];

--- a/src/components/widgets/TextureWidget.js
+++ b/src/components/widgets/TextureWidget.js
@@ -1,7 +1,7 @@
 import React from 'react';
-var INSPECTOR = require('../../lib/inspector.js');
-var Events = require('../../lib/Events.js');
+import INSPECTOR from '../../lib/inspector';
 
+var Events = require('../../lib/Events.js');
 function GetFilename (url) {
   if (url) {
     var m = url.toString().match(/.*\/(.+?)\./);

--- a/src/lib/inspector.js
+++ b/src/lib/inspector.js
@@ -164,7 +164,6 @@ Inspector.prototype = {
   },
   initEvents: function () {
     window.addEventListener('keydown', evt => {
-
       // Alt + Ctrl + i: Shorcut to toggle the inspector
       var shortcutPressed = evt.keyCode === 73 && evt.ctrlKey && evt.altKey;
       if (shortcutPressed) {

--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -53,5 +53,5 @@ module.exports = {
   },
   disable: function () {
     window.removeEventListener('keyup', this.onKeyUp);
-  },
+  }
 };


### PR DESCRIPTION
Before we were exporting `DEFAULT_COMPONENTS` in `CommonComponents.js` this generates and odd error due to circular dependencies when importing `INSPECTOR` in `TextureWidget.js`.
I've fixed it by moving `DEFAULT_COMPONENTS` to a new file `DefaultComponents.js`. 
