### PR TITLE
New sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "clipboard": "^1.5.12",
     "lodash.debounce": "^4.0.6",
     "react": "^15.3.0",
-    "react-dom": "^15.3.0"
+    "react-dom": "^15.3.0",
+    "react-select": "^1.0.0-beta14"
   },
   "devDependencies": {
     "autoprefixer": "^6.3.7",

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -6,7 +6,6 @@ import ReactDOM from 'react-dom';
 
 const Events = require('../lib/Events.js');
 import ComponentsSidebar from './components/Sidebar';
-import ModalTextures from './modals/ModalTextures';
 import SceneGraph from './scenegraph/SceneGraph';
 import ToolBar from './ToolBar';
 
@@ -69,7 +68,6 @@ export default class Main extends React.Component {
 
   render () {
     var scene = this.state.sceneEl;
-    var textureDialogOpened = this.state.isModalTexturesOpen;
     let editButton = <a className='toggle-edit' onClick={this.toggleEdit}>{(this.state.inspectorEnabled ? 'Back to Scene' : 'Inspect Scene')}</a>;
 
     return (
@@ -106,7 +104,7 @@ function injectCSS (url) {
   var webFont = document.createElement('script');
   webFont.src = 'https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js';
   webFont.addEventListener('load', function () {
-    document.head.appendChild(webFontLoader);  
+    document.head.appendChild(webFontLoader);
   });
   webFont.addEventListener('error', function () {
     console.warn('Could not load WebFont script:', webFont.src);

--- a/src/components/components/AddComponent.js
+++ b/src/components/components/AddComponent.js
@@ -15,14 +15,13 @@ export default class AddComponent extends React.Component {
    * If component is instanced, generate an ID.
    */
   addComponent = (componentName) => {
-
     var entity = this.props.entity;
     var select = this.refs.select;
     var selectedOption = this.options.filter(function (option) {
       return option.value === componentName;
     })[0];
 
-    if (origin === 'registry') {
+    if (selectedOption.origin === 'registry') {
       var [packageName, componentName] = selectedOption.value.split('.');
       INSPECTOR.componentLoader.addComponentToScene(packageName, componentName)
         .then(addComponent);

--- a/src/components/components/AddComponent.js
+++ b/src/components/components/AddComponent.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import Collapsible from '../Collapsible';
 import Events from '../../lib/Events';
 var INSPECTOR = require('../../lib/inspector.js');
 import Select from 'react-select';
@@ -16,17 +15,17 @@ export default class AddComponent extends React.Component {
    */
   addComponent = (componentName) => {
     var entity = this.props.entity;
-    var select = this.refs.select;
+    var packageName;
     var selectedOption = this.options.filter(function (option) {
       return option.value === componentName;
     })[0];
 
     if (selectedOption.origin === 'registry') {
-      var [packageName, componentName] = selectedOption.value.split('.');
+      [packageName, componentName] = selectedOption.value.split('.');
       INSPECTOR.componentLoader.addComponentToScene(packageName, componentName)
         .then(addComponent);
     } else {
-      var componentName = selectedOption.value;
+      componentName = selectedOption.value;
       addComponent(componentName);
     }
 
@@ -69,16 +68,16 @@ export default class AddComponent extends React.Component {
           }
         });
       });
-      var registryOptions = registryComponents
-        .sort(function (a, b) {
-          return a.componentName >= b.componentName;
-        })
-        .map(function (item) {
-          return {value: item.componentPackageName+'.'+item.componentName, label: item.componentName, origin: 'registry'};
+    var registryOptions = registryComponents
+      .sort(function (a, b) {
+        return a.componentName >= b.componentName;
+      })
+      .map(function (item) {
+        return {value: item.componentPackageName + '.' + item.componentName,
+          label: item.componentName, origin: 'registry'};
       });
 
-    // return [commonOptions, registryOptions];
-   this.options = commonOptions.concat(registryOptions);
+    this.options = commonOptions.concat(registryOptions);
   }
 
   render () {

--- a/src/components/components/AddComponent.js
+++ b/src/components/components/AddComponent.js
@@ -2,6 +2,8 @@ import React from 'react';
 import Collapsible from '../Collapsible';
 import Events from '../../lib/Events';
 var INSPECTOR = require('../../lib/inspector.js');
+import Select from 'react-select';
+import 'react-select/dist/react-select.css';
 
 export default class AddComponent extends React.Component {
   static propTypes = {
@@ -12,10 +14,13 @@ export default class AddComponent extends React.Component {
    * Add blank component.
    * If component is instanced, generate an ID.
    */
-  addComponent = () => {
+  addComponent = (componentName) => {
+
     var entity = this.props.entity;
-    var selectedOption = this.refs.select.selectedOptions[0];
-    var origin = selectedOption.getAttribute('origin');
+    var select = this.refs.select;
+    var selectedOption = this.options.filter(function (option) {
+      return option.value === componentName;
+    })[0];
 
     if (origin === 'registry') {
       var [packageName, componentName] = selectedOption.value.split('.');
@@ -42,7 +47,7 @@ export default class AddComponent extends React.Component {
   /**
    * Component dropdown options.
    */
-  renderComponentOptions () {
+  getComponentsOptions () {
     const usedComponents = Object.keys(this.props.entity.components);
     var commonOptions = Object.keys(AFRAME.components)
       .filter(function (componentName) {
@@ -51,7 +56,8 @@ export default class AddComponent extends React.Component {
       })
       .sort()
       .map(function (value) {
-        return <option key={value} origin='core' value={value}>{value}</option>;
+//        return <option key={value} origin='core' value={value}>{value}</option>;
+        return {value: value, label: value};
       });
 
     // Create the list of components that should appear in the registry group
@@ -70,40 +76,33 @@ export default class AddComponent extends React.Component {
           return a.componentName >= b.componentName;
         })
         .map(function (item) {
-          return <option key={item.componentName} origin='registry'
-            value={`${item.componentPackageName}.${item.componentName}`}>{item.componentName}</option>
+          return {value: item.componentPackageName+'.'+item.componentName, label: item.componentName, origin: 'registry'};
       });
 
-    return [commonOptions, registryOptions];
+    // return [commonOptions, registryOptions];
+   this.options = commonOptions.concat(registryOptions);
   }
 
   render () {
     const entity = this.props.entity;
     if (!entity) { return <div></div>; }
 
-    var options = this.renderComponentOptions();
+    this.getComponentsOptions();
     return (
-      <Collapsible>
-        <div className='collapsible-header'>
-          <span>COMPONENTS</span>
+        <div className='add-component2'>
+          <Select
+            className="add-component"
+            ref="select"
+            autofocus
+            options={this.options}
+            simpleValue
+            clearable={true}
+            placeholder="Add component..."
+            noResultsText="No components found"
+            onChange={this.addComponent}
+            searchable={true}
+          />
         </div>
-        <div className='collapsible-content'>
-          <div className='row'>
-            <span className='text'>Add</span>
-            <span className='value'>
-              <select ref='select'>
-                <optgroup label="registered">
-                  {options[0]}
-                </optgroup>
-                <optgroup label="registry">
-                  {options[1]}
-                </optgroup>
-              </select>
-              <a className='button fa fa-plus-circle' onClick={this.addComponent}/>
-            </span>
-          </div>
-        </div>
-      </Collapsible>
     );
   }
 }

--- a/src/components/components/AddComponent.js
+++ b/src/components/components/AddComponent.js
@@ -86,7 +86,7 @@ export default class AddComponent extends React.Component {
 
     this.getComponentsOptions();
     return (
-        <div className='add-component2'>
+        <div className='add-component-container'>
           <Select
             className="add-component"
             ref="select"

--- a/src/components/components/AddComponent.js
+++ b/src/components/components/AddComponent.js
@@ -55,8 +55,7 @@ export default class AddComponent extends React.Component {
       })
       .sort()
       .map(function (value) {
-//        return <option key={value} origin='core' value={value}>{value}</option>;
-        return {value: value, label: value};
+        return {value: value, label: value, origin: 'loaded'};
       });
 
     // Create the list of components that should appear in the registry group

--- a/src/components/components/CommonComponents.js
+++ b/src/components/components/CommonComponents.js
@@ -4,10 +4,9 @@ import DEFAULT_COMPONENTS from './DefaultComponents';
 import PropertyRow from './PropertyRow';
 import Collapsible from '../Collapsible';
 import Mixins from './Mixins';
-import {updateEntity} from '../../actions/entity';
+import {updateEntity, getClipboardRepresentation} from '../../actions/entity';
 import Events from '../../lib/Events';
 import Clipboard from 'clipboard';
-import {getClipboardRepresentation} from '../../actions/entity';
 
 // @todo Take this out and use updateEntity?
 function changeId (entity, componentName, propertyName, value) {

--- a/src/components/components/CommonComponents.js
+++ b/src/components/components/CommonComponents.js
@@ -6,6 +6,8 @@ import Collapsible from '../Collapsible';
 import Mixins from './Mixins';
 import {updateEntity} from '../../actions/entity';
 import Events from '../../lib/Events';
+import Clipboard from 'clipboard';
+import {getClipboardRepresentation} from '../../actions/entity';
 
 // @todo Take this out and use updateEntity?
 function changeId (entity, componentName, propertyName, value) {
@@ -25,6 +27,15 @@ export default class CommonComponents extends React.Component {
       if (DEFAULT_COMPONENTS.indexOf(detail.name) !== -1) {
         this.forceUpdate();
       }
+    });
+
+    var clipboard = new Clipboard('[data-action="copy-entity-to-clipboard"]', {
+      text: trigger => {
+        return getClipboardRepresentation(this.props.entity);
+      }
+    });
+    clipboard.on('error', e => {
+      // @todo Show the error on the UI
     });
   }
 
@@ -47,10 +58,17 @@ export default class CommonComponents extends React.Component {
   render () {
     const entity = this.props.entity;
     if (!entity) { return <div></div>; }
+    const entityName = '<' + entity.tagName.toLowerCase() + '>';
+    const entityButtons = <div>
+      <a href='#' title='Copy entity HTML to clipboard' data-action='copy-entity-to-clipboard'
+        className='button fa fa-clipboard' onClick={event => event.stopPropagation()}></a>
+    </div>;
+
     return (
       <Collapsible>
         <div className='collapsible-header'>
-          <span>COMMON</span>
+          <span className='entity-name'>{entityName}</span>
+          {entityButtons}
         </div>
         <div className='collapsible-content'>
           <div className='row'>

--- a/src/components/components/Sidebar.js
+++ b/src/components/components/Sidebar.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import ComponentsContainer from './ComponentsContainer';
-import Clipboard from 'clipboard';
-import {getClipboardRepresentation} from '../../actions/entity';
 import Events from '../../lib/Events';
 
 export default class Sidebar extends React.Component {
@@ -18,15 +16,6 @@ export default class Sidebar extends React.Component {
   }
 
   componentDidMount () {
-    var clipboard = new Clipboard('[data-action="copy-entity-to-clipboard"]', {
-      text: trigger => {
-        ga('send', 'event', 'Components', 'copyEntityToClipboard');
-        return getClipboardRepresentation(this.state.entity);
-      }
-    });
-    clipboard.on('error', e => {
-      // @todo Show the error on the UI
-    });
 
     Events.on('componentRemoved', event => {
       this.forceUpdate();
@@ -61,18 +50,8 @@ export default class Sidebar extends React.Component {
   render () {
     const entity = this.state.entity;
     if (entity) {
-      const entityButtons = <div>
-        <a href='#' title='Copy entity HTML to clipboard' data-action='copy-entity-to-clipboard'
-          className='button fa fa-clipboard' onClick={event => event.stopPropagation()}></a>
-      </div>;
-      const entityName = '<' + entity.tagName.toLowerCase() + '>';
-
       return (
         <div id='sidebar'>
-          <div className='sidebar-title'>
-            <code>{entityName}</code>
-            {entityButtons}
-          </div>
           <ComponentsContainer entity={this.state.entity}/>
         </div>
       );

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -18,7 +18,6 @@ export default class SelectWidget extends React.Component {
   }
 
   onChange = value => {
-    //var value = e.target.value;
     this.setState({value: value});
     if (this.props.onChange) {
       this.props.onChange(this.props.entity, this.props.componentname, this.props.name, value);
@@ -39,8 +38,8 @@ export default class SelectWidget extends React.Component {
 
   render () {
     var options = this.props.options.map(value => {
-      return {value: value, label:value};
-    })
+      return {value: value, label: value};
+    });
 
     return (
       <Select

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -1,4 +1,6 @@
 var React = require('react');
+import Select from 'react-select';
+import 'react-select/dist/react-select.css';
 
 export default class SelectWidget extends React.Component {
   static propTypes = {
@@ -15,8 +17,8 @@ export default class SelectWidget extends React.Component {
     this.state = {value: this.props.value || ''};
   }
 
-  onChange = e => {
-    var value = e.target.value;
+  onChange = value => {
+    //var value = e.target.value;
     this.setState({value: value});
     if (this.props.onChange) {
       this.props.onChange(this.props.entity, this.props.componentname, this.props.name, value);
@@ -36,10 +38,23 @@ export default class SelectWidget extends React.Component {
   }
 
   render () {
+    var options = this.props.options.map(value => {
+      return {value: value, label:value};
+    })
+
     return (
-      <select value={this.state.value} onChange={this.onChange}>
-        { this.renderOptions() }
-      </select>
+      <Select
+        className="select-widget"
+        options={options}
+        simpleValue
+        clearable={true}
+        placeholder=""
+        value={this.state.value}
+        noResultsText="No value found"
+        onChange={this.onChange}
+        searchable={true}
+      />
+
     );
   }
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -264,7 +264,7 @@ div.vec3 {
 }
 
 .vec3 input.number {
-  width: 50px;
+  width: 46px;
 }
 
 .collapsible-header {
@@ -599,6 +599,7 @@ select {
   font-family: Consolas, Andale Mono, Monaco, Courier New, monospace;
 }
 
+.Select,
 .wf-active code,
 .wf-active pre,
 .wf-active input,
@@ -817,7 +818,7 @@ span.entity-name {
 
 .select-widget {
   display: inline-block;
-  width: 188px;
+  width: 157px;
 }
 
 .Select-placeholder, .Select--single > .Select-control .Select-value {
@@ -835,7 +836,7 @@ span.entity-name {
 
 .row .Select-placeholder,
 .row .Select--single > .Select-control .Select-value {
-  line-height: 23px;
+  line-height: 19px;
 }
 
 .row .Select-input{

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -296,7 +296,7 @@ div.vec3 {
 }
 
 .collapsible .menu:after {
-  color: #1faaf2;
+  color: #BBB;
   content: '\2807';
   font-size: 12px;
   padding: 5px;
@@ -314,11 +314,11 @@ div.vec3 {
 }
 
 .collapsible.collapsed .static .collapse-button {
-  border-left-color: #1faaf2;
+  border-left-color: #BBB;
 }
 
 .collapsible:not(.collapsed) .static .collapse-button {
-  border-top-color: #1faaf2;
+  border-top-color: #BBB;
 }
 
 .collapsible .content {
@@ -772,4 +772,85 @@ a.help-link:hover {
   position: fixed;
   background-color: #191919;
   z-index: 9999;
+}
+
+span.entity-name {
+  font-family: Consolas, Andale Mono, Monaco, Courier New, monospace;
+  color: #fff;
+  font-size: 16px;
+}
+
+.add-component {
+  width: 200px;
+}
+
+.Select-control {
+  background-color: #222 !important;
+  border-radius: 0;
+  color: #1faaf2;
+  border: none;
+}
+
+.add-component {
+  text-align: left;
+}
+
+.add-component2 {
+  display: flex;
+  justify-content: center;
+  background-color: #2b2b2b;
+  padding: 10px;
+}
+
+.Select-menu-outer {
+  border: none;
+}
+
+.Select-menu-outer .is-focused {
+  background-color: #1faaf2 !important;
+  color: #fff;
+}
+
+.Select-option {
+  background-color: #222 !important;
+}
+
+.select-widget {
+  display: inline-block;
+  width: 188px;
+}
+
+.Select-placeholder, .Select--single > .Select-control .Select-value {
+  color: #1faaf2 !important;
+}
+
+.Select-value-label {
+  color: #1faaf2 !important;
+}
+
+.row .Select-control {
+  height: 24px;
+  font-size: 11px;
+}
+
+.row .Select-placeholder,
+.row .Select--single > .Select-control .Select-value {
+  line-height: 23px;
+}
+
+.row .Select-input{
+  height: 22px;
+}
+
+
+.row input[type=text],
+.row input[type=number],
+.row input.string,
+.row input.number {
+  min-height: 20px;
+  padding-left: 5px;
+  padding-right: 5px;
+  color: #1faaf2;
+  border: 1px solid transparent;
+  background: #222;
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -796,7 +796,7 @@ span.entity-name {
   text-align: left;
 }
 
-.add-component2 {
+.add-component-container {
   display: flex;
   justify-content: center;
   background-color: #2b2b2b;

--- a/src/lib/componentloader.js
+++ b/src/lib/componentloader.js
@@ -35,7 +35,6 @@ ComponentLoader.prototype = {
    */
   addComponentToScene: function (packageName, componentName) {
     const component = this.components[packageName];
-
     if (component.included) { return Promise.resolve(componentName); }
 
     let script = document.createElement('script');


### PR DESCRIPTION
- Added `react-select` for selectboxes, and style them
- Style sidebar according to the ideas from @feiss (https://github.com/aframevr/aframe-inspector/issues/316 - _Still a lot to do but will address that in another PR._):
  - Bigger sidebar title
  - `Add component` is _part of_ the common attributes panel, but if you collapse commons, it `Add component` will still be visible.
  - `Add component` replaced previous selectbox with an autocomplete selectbox.
- Fixes a problem when scrolling sidebar that it prevented us to see the latests attributes.

![newsidebar](https://cloud.githubusercontent.com/assets/782511/19372481/cb336a1a-91bc-11e6-817f-d35d9d65e00c.gif)
