### PR TITLE
Added help modal for shortcuts

### DIFF
--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -6,6 +6,7 @@ import ReactDOM from 'react-dom';
 
 const Events = require('../lib/Events.js');
 import ComponentsSidebar from './components/Sidebar';
+import ModalHelp from './modals/ModalHelp';
 import SceneGraph from './scenegraph/SceneGraph';
 import ToolBar from './ToolBar';
 
@@ -45,6 +46,14 @@ export default class Main extends React.Component {
     Events.on('inspectorModeChanged', enabled => {
       this.setState({inspectorEnabled: enabled});
     });
+
+    Events.on('openHelpModal', () => {
+      this.setState({isHelpOpen: true});
+    });
+  }
+
+  onCloseHelpModal = value => {
+    this.setState({isHelpOpen: false});
   }
 
   onModalTextureOnClose = value => {
@@ -82,6 +91,7 @@ export default class Main extends React.Component {
             <ComponentsSidebar entity={this.state.entity}/>
           </div>
         </div>
+        <ModalHelp isOpen={this.state.isHelpOpen} onClose={this.onCloseHelpModal}/>
       </div>
     );
   }

--- a/src/components/modals/Modal.js
+++ b/src/components/modals/Modal.js
@@ -24,6 +24,9 @@ export default class Modal extends React.Component {
   handleGlobalKeydown = event => {
     if (this.state.isOpen && event.keyCode === 27) {
       this.close();
+
+      // Prevent closing the inspector
+      event.stopPropagation();
     }
   }
 

--- a/src/components/modals/Modal.js
+++ b/src/components/modals/Modal.js
@@ -7,6 +7,7 @@ export default class Modal extends React.Component {
       React.PropTypes.element
     ]).isRequired,
     isOpen: React.PropTypes.bool,
+    extraCloseKeyCode: React.PropTypes.number,
     onClose: React.PropTypes.func,
     title: React.PropTypes.string
   };
@@ -22,7 +23,8 @@ export default class Modal extends React.Component {
   }
 
   handleGlobalKeydown = event => {
-    if (this.state.isOpen && event.keyCode === 27) {
+    if (this.state.isOpen && (event.keyCode === 27 ||
+      this.props.extraCloseKeyCode && event.keyCode === this.props.extraCloseKeyCode)) {
       this.close();
 
       // Prevent closing the inspector

--- a/src/components/modals/ModalHelp.js
+++ b/src/components/modals/ModalHelp.js
@@ -48,7 +48,7 @@ export default class ModalHelp extends React.Component {
     ];
 
     return (
-      <Modal title="Shortcuts" isOpen={this.state.isOpen} onClose={this.onClose}>
+      <Modal title="Shortcuts" isOpen={this.state.isOpen} onClose={this.onClose} extraCloseKeyCode={72}>
         <div className="help-lists">
         {
           shortcuts.map(function (column, idx) {

--- a/src/components/modals/ModalHelp.js
+++ b/src/components/modals/ModalHelp.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import Modal from './Modal';
+
+export default class ModalHelp extends React.Component {
+  static propTypes = {
+    isOpen: React.PropTypes.bool,
+    onClose: React.PropTypes.func
+  };
+
+  constructor (props) {
+    super(props);
+    this.state = {
+      isOpen: this.props.isOpen
+    };
+  }
+
+  componentWillReceiveProps (newProps) {
+    if (this.state.isOpen !== newProps.isOpen) {
+      this.setState({isOpen: newProps.isOpen});
+    }
+  }
+
+  onClose = value => {
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
+  }
+
+  render () {
+    var self = this;
+
+    let shortcuts = [
+      [
+        {key: ['w'], description: 'Translate'},
+        {key: ['e'], description: 'Rotate'},
+        {key: ['r'], description: 'Scale'},
+        {key: ['d'], description: 'Duplicate selected entity'},
+        {key: ['g'], description: 'Toggle grid visibility'},
+        {key: ['n'], description: 'Add new entity'}
+      ],
+      [
+        {key: ['h'], description: 'Show this help'},
+        {key: ['supr'], description: 'Delete selected entity'},
+        {key: ['Esc'], description: 'Exit edit mode'},
+        {key: ['backspace'], description: 'Delete selected entity'},
+        {key: ['ctrl','alt','i'], description: 'Switch Edit and VR Modes'}
+      ]
+    ];
+
+    return (
+      <Modal title="Shortcuts" isOpen={this.state.isOpen} onClose={this.onClose}>
+        <div className="help-lists">
+        {
+          shortcuts.map(function (column, idx) {
+            return <ul className="help-list" key={idx}>
+            {
+              column.map(function (shortcut) {
+                return (
+                  <li key={shortcut.key} className="help-key-unit">
+                  {
+                    shortcut.key.map(function (key) {
+                      return <kbd key={key} className="help-key"><span>{key}</span></kbd>
+                    })
+                  }
+                  <span className="help-key-def">{shortcut.description}</span>
+                  </li>
+                )
+              })
+            }
+            </ul>
+          })
+        }
+        </div>
+      </Modal>
+    );
+  }
+}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -389,7 +389,7 @@ a.button:hover {
 
 .modal {
   position: fixed;
-  z-index: 1;
+  z-index: 9999;
   padding-top: 100px;
   left: 0;
   top: 0;
@@ -854,4 +854,56 @@ span.entity-name {
   color: #1faaf2;
   border: 1px solid transparent;
   background: #222;
+
+/* shortcuts help */
+.help-lists {
+  display: flex;
+  justify-content: space-around;
+}
+
+.help-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 10px 0;
+  width: 350px;
+}
+
+.help-list li {
+  margin-right: 40px;
+}
+
+.help-key-unit {
+  line-height: 1.8;
+  margin-right: 2em;
+  padding: 5px 0;
+}
+
+.help-key {
+  min-width: 60px;
+  position: relative;
+  bottom: 2px;
+  margin-right: 4px;
+}
+
+.help-key span {
+  font-size: 12px;
+  color: #555;
+  display: inline-block;
+  padding: 0 8px;
+  text-align: center;
+  background-color: #eee;
+  background-repeat: repeat-x;
+  background-image: linear-gradient(#f5f5f5 0%, #eee 100%);
+  border: 1px solid #ccc;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  border-radius: 3px;
+  -webkit-box-shadow: inset 0 1px 0 #fff, 0 1px 0 #ccc;
+  box-shadow: inset 0 1px 0 #fff, 0 1px 0 #ccc;
+}
+
+.help-key-def {
+  display: inline-block;
+  margin-left: 1em;
+  color: #BBB;
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -887,19 +887,15 @@ span.entity-name {
 
 .help-key span {
   font-size: 12px;
-  color: #555;
+  color: #999;
   display: inline-block;
   padding: 0 8px;
   text-align: center;
-  background-color: #eee;
+  background-color: #2e2e2e;
   background-repeat: repeat-x;
-  background-image: linear-gradient(#f5f5f5 0%, #eee 100%);
-  border: 1px solid #ccc;
-  -webkit-border-radius: 3px;
-  -moz-border-radius: 3px;
+  border: 1px solid #666;
   border-radius: 3px;
-  -webkit-box-shadow: inset 0 1px 0 #fff, 0 1px 0 #ccc;
-  box-shadow: inset 0 1px 0 #fff, 0 1px 0 #ccc;
+  box-shadow: 0 0 5px #000;
 }
 
 .help-key-def {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -843,7 +843,6 @@ span.entity-name {
   height: 22px;
 }
 
-
 .row input[type=text],
 .row input[type=number],
 .row input.string,
@@ -854,6 +853,7 @@ span.entity-name {
   color: #1faaf2;
   border: 1px solid transparent;
   background: #222;
+}
 
 /* shortcuts help */
 .help-lists {

--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -7,6 +7,11 @@ module.exports = {
   onKeyUp: function (event) {
     if (!shouldCaptureKeyEvent(event)) { return; }
 
+    // h: help
+    if (event.keyCode === 72) {
+      Events.emit('openHelpModal');
+    }
+
     // esc: close inspector
     if (event.keyCode === 27) {
       AFRAME.INSPECTOR.close();


### PR DESCRIPTION
It shows up when pressing `h` and close by clicking `X` or pressing `esc`

![helpmodal](https://cloud.githubusercontent.com/assets/782511/19389127/fc634978-9222-11e6-8420-3bcef6dd2f7d.gif)

It also fixed a bug as we didn't call `stopPropagation` when listening for `esc` key on modals, and we were closing the modal and exiting the inspector at the same time.

Restyled based on @feiss proposal:
![image](https://cloud.githubusercontent.com/assets/782511/19391720/15c5dcfe-922e-11e6-9a3e-b72d95ac6abb.png)
