### PR TITLE
Fixes #349: Newly created entities were no selectable from the viewport

### DIFF
--- a/example/empty.html
+++ b/example/empty.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Example Scene</title>
+    <script src="js/aframe.min.js"></script>
+  </head>
+  <body>
+    <a-scene stats>
+    </a-scene>
+    <script src="http://localhost:3333/build/aframe-inspector.js"></script>
+  </body>
+</html>

--- a/src/components/components/Sidebar.js
+++ b/src/components/components/Sidebar.js
@@ -35,13 +35,20 @@ export default class Sidebar extends React.Component {
     Events.emit('selectedentitycomponentchanged', event.detail);
   }
 
+  componentCreated = (event) => {
+    Events.emit('selectedEntityComponentCreated', event.detail);
+  }
+
   componentWillReceiveProps (newProps) {
     if (this.state.entity !== newProps.entity) {
       if (this.state.entity) {
         this.state.entity.removeEventListener('componentchanged', this.componentChanged);
+        this.state.entity.removeEventListener('componentinitialized', this.componentCreated);
       }
       if (newProps.entity) {
         newProps.entity.addEventListener('componentchanged', this.componentChanged);
+        newProps.entity.addEventListener('componentinitialized', this.componentCreated);
+
       }
       this.setState({entity: newProps.entity});
     }

--- a/src/lib/inspector.js
+++ b/src/lib/inspector.js
@@ -108,8 +108,19 @@ Inspector.prototype = {
     var geometry = new THREE.SphereBufferGeometry(2, 4, 2);
     var material = new THREE.MeshBasicMaterial({ color: 0xff0000, visible: false });
 
-    return function (object) {
+    return function (object, parent) {
       var helper;
+
+      // Helpers for object already created, remove every helper
+      if (this.helpers[parent.id]) {
+        for (var objectId in this.helpers[parent.id]) {
+          helper = this.helpers[parent.id][objectId];
+          this.sceneHelpers.remove(helper);
+        }
+      } else {
+        this.helpers[parent.id] = {};
+      }
+
       if (object instanceof THREE.Camera) {
         helper = new THREE.CameraHelper(object, 1);
       } else if (object instanceof THREE.PointLight) {
@@ -133,21 +144,26 @@ Inspector.prototype = {
       helper.add(picker);
 
       this.sceneHelpers.add(helper);
-      this.helpers[ object.id ] = helper;
+      this.helpers[parent.id][object.id] = helper;
 
       Events.emit('helperadded', helper);
     };
   })(),
 
   removeHelper: function (object) {
-    if (this.helpers[ object.id ] !== undefined) {
-      var helper = this.helpers[ object.id ];
+    /*
+    var parentId = object.parent.id;
+    var objectId = object.id;
+    console.log(this.helpers, parentId, objectId);
+    if (this.helpers[parentId][objectId] !== undefined) {
+      var helper = this.helpers[parentId][objectId];
       helper.parent.remove(helper);
 
-      delete this.helpers[ object.id ];
+      delete this.helpers[parentId][objectId];
 
       Events.emit('helperremoved', helper);
     }
+    */////////!!!!!!!!
   },
 
   selectEntity: function (entity, emit) {
@@ -296,7 +312,7 @@ Inspector.prototype = {
     var scope = this;
     object.traverse(child => {
       if (!child.el || !child.el.isInspector) {
-        scope.addHelper(child);
+        scope.addHelper(child, object);
       }
     });
 

--- a/src/lib/inspector.js
+++ b/src/lib/inspector.js
@@ -90,7 +90,11 @@ Inspector.prototype = {
       this.addObject(event.target.object3D);
     });
 
-    document.addEventListener('selectedEntityComponentChanged', event => {
+    Events.on('selectedEntityComponentChanged', event => {
+      this.addObject(event.target.object3D);
+    });
+
+    Events.on('selectedEntityComponentCreated', event => {
       this.addObject(event.target.object3D);
     });
 
@@ -101,26 +105,15 @@ Inspector.prototype = {
 
   removeObject: function (object) {
     // Remove just the helper as the object will be deleted by Aframe
-    object.traverse(this.removeHelper.bind(this));
+    this.removeHelpers(object);
   },
 
   addHelper: (function () {
     var geometry = new THREE.SphereBufferGeometry(2, 4, 2);
     var material = new THREE.MeshBasicMaterial({ color: 0xff0000, visible: false });
 
-    return function (object, parent) {
+    return function (object) {
       var helper;
-
-      // Helpers for object already created, remove every helper
-      if (this.helpers[parent.id]) {
-        for (var objectId in this.helpers[parent.id]) {
-          helper = this.helpers[parent.id][objectId];
-          this.sceneHelpers.remove(helper);
-        }
-      } else {
-        this.helpers[parent.id] = {};
-      }
-
       if (object instanceof THREE.Camera) {
         helper = new THREE.CameraHelper(object, 1);
       } else if (object instanceof THREE.PointLight) {
@@ -138,32 +131,48 @@ Inspector.prototype = {
         return;
       }
 
+      var parentId = object.parent.id;
+
+      // Helpers for object already created, remove every helper
+      if (this.helpers[parentId]) {
+        for (var objectId in this.helpers[parentId]) {
+          this.sceneHelpers.remove(this.helpers[parentId][objectId]);
+        }
+      } else {
+        this.helpers[parentId] = {};
+      }
+
       var picker = new THREE.Mesh(geometry, material);
       picker.name = 'picker';
       picker.userData.object = object;
       helper.add(picker);
+      helper.fromObject = object;
 
       this.sceneHelpers.add(helper);
-      this.helpers[parent.id][object.id] = helper;
+      this.helpers[parentId][object.id] = helper;
 
       Events.emit('helperadded', helper);
     };
   })(),
 
-  removeHelper: function (object) {
-    /*
-    var parentId = object.parent.id;
-    var objectId = object.id;
-    console.log(this.helpers, parentId, objectId);
-    if (this.helpers[parentId][objectId] !== undefined) {
-      var helper = this.helpers[parentId][objectId];
-      helper.parent.remove(helper);
-
+  removeHelpers: function (object) {
+    var parentId = object.id;
+/*
+<<<<<<< d94d0485f83427a26999095d0c064fa0ed10ac59
       delete this.helpers[parentId][objectId];
 
       Events.emit('helperremoved', helper);
+=======
+    if (this.helpers[parentId]) {
+      for (var objectId in this.helpers[parentId]) {
+        var helper = this.helpers[parentId][objectId];
+        Events.emit('helperRemoved', helper);
+        this.sceneHelpers.remove(helper);
+      }
+      delete this.helpers[parentId];
+>>>>>>> Use componentInitialized for newly created components
+*/
     }
-    */////////!!!!!!!!
   },
 
   selectEntity: function (entity, emit) {

--- a/src/lib/viewport/index.js
+++ b/src/lib/viewport/index.js
@@ -54,10 +54,9 @@ function Viewport (inspector) {
    * @param  {object3D} object Object to update
    */
   function updateHelpers (object) {
-    for (var i = 0; i < object.children.length; i++) {
-      var child = object.children[i];
-      if (inspector.helpers[child.id] !== undefined) {
-        inspector.helpers[child.id].update();
+    if (inspector.helpers[object.id] !== undefined) {
+      for (var objectId in inspector.helpers[object.id]) {
+        inspector.helpers[object.id][objectId].update();
       }
     }
   }
@@ -322,7 +321,6 @@ function Viewport (inspector) {
     object.traverse(child => {
       if (objects.indexOf(child) === -1) {
         objects.push(child);
-        console.log('Added', child);
       }
     });
   });
@@ -355,6 +353,7 @@ function Viewport (inspector) {
   });
   Events.on('helperadded', object => {
     objects.push(object.getObjectByName('picker'));
+//!!!    updateHelpers(helper.fromObject.parent);
   });
   Events.on('helperremoved', object => {
     objects.splice(objects.indexOf(object.getObjectByName('picker')), 1);

--- a/src/lib/viewport/index.js
+++ b/src/lib/viewport/index.js
@@ -320,7 +320,10 @@ function Viewport (inspector) {
 
   Events.on('objectadded', object => {
     object.traverse(child => {
-      objects.push(child);
+      if (objects.indexOf(child) === -1) {
+        objects.push(child);
+        console.log('Added', child);
+      }
     });
   });
 


### PR DESCRIPTION
- Allow newly created entities to be selected on the viewport aswell as its helpers
- Start using `componentinitialized` for newly created components.
- Created `empty.html` to use for testing empty scenes
