### PR TITLE
Added ellipsis to property name

### DIFF
--- a/src/components/components/PropertyRow.js
+++ b/src/components/components/PropertyRow.js
@@ -80,7 +80,7 @@ export default class PropertyRow extends React.Component {
 
   render () {
     const props = this.props;
-    const title = 'type: ' + props.schema.type + ' value: ' + JSON.stringify(props.data);
+    const title = props.name + '\n - type: ' + props.schema.type + '\n - value: ' + JSON.stringify(props.data);
     const helpLink = props.showHelp ? getComponentDocsHtmlLink(props.name) : '';
     return (
       <div className='row'>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -339,6 +339,8 @@ div.vec3 {
   display: inline-block;
   vertical-align: middle;
   width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .components .row .map_value {


### PR DESCRIPTION
- Added `text-overflow: ellipsis` to property names
- Added property name on property name's `title` attribute 

Before:
![image](https://cloud.githubusercontent.com/assets/782511/19434928/780651aa-9468-11e6-98e4-d9ebcbf6568d.png)

Now:
<img width="304" alt="screenshot 2016-10-17 12 53 34" src="https://cloud.githubusercontent.com/assets/782511/19434993/c68438c4-9468-11e6-9c35-890519fb33b9.png">
