### PR TITLE
Fixes #341 Added a-frame registry icon

### DIFF
--- a/assets/a-registry-logo-min.svg
+++ b/assets/a-registry-logo-min.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg2" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="100mm" width="100mm" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" viewBox="0 0 354.33071 354.33071">
+ <metadata id="metadata7">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g id="layer1" fill="#fff" transform="translate(0 -698.03)">
+  <path id="text3336" d="m102.28 749.3-88.657 293.97h72.114l14.848-63.206h86.112l14.845 63.206h73.81l-34.36-113.69-128.53 0.00011 30.967-129.8v-50.48z"/>
+  <rect id="rect3356" transform="rotate(237.21)" height="79.557" width="79.557" y="-311.53" x="-785.82"/>
+  <rect id="rect3362" transform="matrix(-.78208 .62317 -.62317 -.78208 0 0)" height="95.238" width="95.238" y="-885.85" x="318.72"/>
+  <rect id="rect3364" transform="rotate(12.582)" height="95.238" width="95.238" y="633.02" x="396.31"/>
+ </g>
+</svg>

--- a/src/components/components/AddComponent.js
+++ b/src/components/components/AddComponent.js
@@ -99,6 +99,9 @@ export default class AddComponent extends React.Component {
             onChange={this.addComponent}
             searchable={true}
           />
+          <a href="https://aframe.io/aframe-registry" target="_blank" title="A-Frame Registry" className="button aregistry">
+            <img src="https://aframe.io/aframe-inspector/assets/a-registry-logo-min.svg"/>
+          </a>
         </div>
     );
   }

--- a/src/components/components/AddComponent.js
+++ b/src/components/components/AddComponent.js
@@ -99,8 +99,8 @@ export default class AddComponent extends React.Component {
             onChange={this.addComponent}
             searchable={true}
           />
-          <a href="https://aframe.io/aframe-registry" target="_blank" title="A-Frame Registry" className="button aregistry">
-            <img src="https://aframe.io/aframe-inspector/assets/a-registry-logo-min.svg"/>
+          <a href="https://aframe.io/aframe-registry" target="_blank" title="A-Frame Registry" className="aregistry-button">
+            <img src="../assets/a-registry-logo-min.svg"/>
           </a>
         </div>
     );

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -794,17 +794,6 @@ span.entity-name {
   border: none;
 }
 
-.add-component {
-  text-align: left;
-}
-
-.add-component-container {
-  display: flex;
-  justify-content: center;
-  background-color: #2b2b2b;
-  padding: 10px;
-}
-
 .Select-menu-outer {
   border: none;
 }
@@ -904,4 +893,29 @@ span.entity-name {
   display: inline-block;
   margin-left: 1em;
   color: #BBB;
+}
+
+.add-component {
+  text-align: left;
+}
+
+.add-component-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #2b2b2b;
+  padding: 10px;
+}
+
+.aregistry {
+  padding: 6px;
+}
+
+.aregistry:hover {
+  background-color: #1faaf2;
+}
+
+.aregistry img {
+  width: 20px;
+  height: 20px;
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -907,15 +907,17 @@ span.entity-name {
   padding: 10px;
 }
 
-.aregistry {
-  padding: 6px;
+.aregistry-button {
+  padding: 8px;
+  font-size: 12px;
+  margin-left: 10px;
 }
 
-.aregistry:hover {
+.aregistry-button:hover {
   background-color: #1faaf2;
 }
 
-.aregistry img {
+.aregistry-button img {
   width: 20px;
   height: 20px;
 }


### PR DESCRIPTION
Added a button with a link to https://aframe.io/aframe-registry next to the `Add component` selectbox with the logo designed by @feiss
_Note that the img url is absolute to the aframe-inspector so it won't work until deployed_

![image](https://cloud.githubusercontent.com/assets/782511/19444399/969f51de-9490-11e6-86e0-bd0ab07105d5.png)

![image](https://cloud.githubusercontent.com/assets/782511/19444406/9c43b530-9490-11e6-8619-f4fa40a1783d.png)
