### PR TITLE
Fix #354 implement vec2 widget

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -6,7 +6,7 @@
     <script src="js/aframe.min.js"></script>
   </head>
   <body>
-    <a-scene>
+    <a-scene debug="true">
       <a-assets>
         <a-mixin id="blue" material="color: #4CC3D9"></a-mixin>
         <a-mixin id="blueBox" geometry="primitive: box; depth: 2; height: 5; width: 1" material="color: #4CC3D9"></a-mixin>

--- a/src/actions/entity.js
+++ b/src/actions/entity.js
@@ -12,28 +12,26 @@ import DEFAULT_COMPONENTS from '../components/components/DefaultComponents';
  * @param {string} property - Property name.
  * @param {string|number} value - New value.
  */
-export function updateEntity (entity, componentName, propertyName, value) {
-  var isSingle = isSingleProperty(components[entity.components[componentName].name].schema);
-
-  if (propertyName && !isSingle) {
-    // Multi-prop.
+export function updateEntity (entity, propertyName, value) {
+  if (propertyName.indexOf('.') !== -1) {
+    // Multi-prop
+    var splitName = propertyName.split('.');
     if (value === null || value === undefined) {
       // Remove property.
-      var parameters = entity.getAttribute(componentName);
-      delete parameters[propertyName];
-      entity.setAttribute(componentName, parameters);
+      var parameters = entity.getAttribute(splitName[0]);
+      delete parameters[splitName[1]];
+      entity.setAttribute(splitName[0], parameters);
     } else {
       // Set property.
-      entity.setAttribute(componentName, propertyName, value);
+      entity.setAttribute(splitName[0], splitName[1], value);
     }
   } else {
-    // Single-prop.
     if (value === null || value === undefined) {
       // Remove property.
-      entity.removeAttribute(componentName);
+      entity.removeAttribute(propertyName);
     } else {
       // Set property.
-      entity.setAttribute(componentName, value);
+      entity.setAttribute(propertyName, value);
     }
   }
   Events.emit('objectchanged', entity.object3D);

--- a/src/components/components/CommonComponents.js
+++ b/src/components/components/CommonComponents.js
@@ -49,7 +49,7 @@ export default class CommonComponents extends React.Component {
       return (
         <PropertyRow onChange={updateEntity} key={componentName} name={componentName}
           showHelp={true} schema={schema} data={componentData.data}
-          componentname={componentName} entity={entity}/>
+          isSingle={true} componentname={componentName} entity={entity}/>
       );
     });
   }

--- a/src/components/components/Component.js
+++ b/src/components/components/Component.js
@@ -77,7 +77,7 @@ export default class Component extends React.Component {
       return (
         <PropertyRow key={componentName} name={componentName} schema={schema}
           data={componentData.data} componentname={componentName}
-          entity={this.props.entity}/>
+          isSingle={true} entity={this.props.entity}/>
       );
     }
 
@@ -85,7 +85,7 @@ export default class Component extends React.Component {
       <PropertyRow key={propertyName} name={propertyName}
         schema={componentData.schema[propertyName]}
         data={componentData.data[propertyName]} componentname={this.props.name}
-        entity={this.props.entity}/>
+        isSingle={false} entity={this.props.entity}/>
     ));
   }
 

--- a/src/components/components/PropertyRow.js
+++ b/src/components/components/PropertyRow.js
@@ -8,6 +8,7 @@ import NumberWidget from '../widgets/NumberWidget';
 import SelectWidget from '../widgets/SelectWidget';
 import TextureWidget from '../widgets/TextureWidget';
 import Vec3Widget from '../widgets/Vec3Widget';
+import Vec2Widget from '../widgets/Vec2Widget';
 import {updateEntity} from '../../actions/entity';
 import {getComponentDocsHtmlLink} from '../../actions/component';
 
@@ -36,10 +37,16 @@ export default class PropertyRow extends React.Component {
     const widgetProps = {
       componentname: props.componentname,
       entity: props.entity,
+      isSingle: props.isSingle,
       name: props.name,
       // Wrap updateEntity for tracking.
-      onChange: function () {
-        updateEntity.apply(this, arguments);
+      onChange: function (name, value) {
+        var propertyName = props.componentname;
+        if (!props.isSingle) {
+          propertyName +='.' + props.name;
+        }
+
+        updateEntity.apply(this, [props.entity, propertyName, value]);
         gaTrackComponentUpdate();
       },
       value: props.data
@@ -62,6 +69,9 @@ export default class PropertyRow extends React.Component {
       }
       case 'int': {
         return <NumberWidget {...widgetProps} {...numberWidgetProps} precision={0}/>;
+      }
+      case 'vec2': {
+        return <Vec2Widget {...widgetProps}/>;
       }
       case 'vec3': {
         return <Vec3Widget {...widgetProps}/>;

--- a/src/components/widgets/BooleanWidget.js
+++ b/src/components/widgets/BooleanWidget.js
@@ -28,7 +28,7 @@ export default class BooleanWidget extends React.Component {
     var value = e.target.checked;
     this.setState({value: value});
     if (this.props.onChange) {
-      this.props.onChange(this.props.entity, this.props.componentname, this.props.name, value);
+      this.props.onChange(this.props.name, value);
     }
   }
 

--- a/src/components/widgets/ColorWidget.js
+++ b/src/components/widgets/ColorWidget.js
@@ -28,7 +28,7 @@ export default class ColorWidget extends React.Component {
     var value = e.target.value;
     this.setState({value: value});
     if (this.props.onChange) {
-      this.props.onChange(this.props.entity, this.props.componentname, this.props.name, value);
+      this.props.onChange(this.props.name, value);
     }
   }
 

--- a/src/components/widgets/InputWidget.js
+++ b/src/components/widgets/InputWidget.js
@@ -18,7 +18,7 @@ export default class InputWidget extends React.Component {
     var value = e.target.value;
     this.setState({value: value});
     if (this.props.onChange) {
-      this.props.onChange(this.props.entity, this.props.componentname, this.props.name, value);
+      this.props.onChange(this.props.name, value);
     }
   }
 

--- a/src/components/widgets/NumberWidget.js
+++ b/src/components/widgets/NumberWidget.js
@@ -93,8 +93,7 @@ export default class NumberWidget extends React.Component {
       this.setState({value: value, displayValue: value.toFixed(this.props.precision)});
 
       if (this.props.onChange) {
-        this.props.onChange(this.props.entity, this.props.componentname, this.props.name,
-                            value);
+        this.props.onChange(this.props.name, value);
       }
     }
   }

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -20,7 +20,7 @@ export default class SelectWidget extends React.Component {
   onChange = value => {
     this.setState({value: value});
     if (this.props.onChange) {
-      this.props.onChange(this.props.entity, this.props.componentname, this.props.name, value);
+      this.props.onChange(this.props.name, value);
     }
   }
 

--- a/src/components/widgets/TextureWidget.js
+++ b/src/components/widgets/TextureWidget.js
@@ -141,7 +141,7 @@ export default class TextureWidget extends React.Component {
 
   notifyChanged = value => {
     if (this.props.onChange) {
-      this.props.onChange(this.props.entity, this.props.componentname, this.props.name, value);
+      this.props.onChange(this.props.name, value);
     }
     this.setState({value: value});
   }
@@ -169,7 +169,7 @@ export default class TextureWidget extends React.Component {
         value = '#' + assetId;
       }
       if (this.props.onChange) {
-        this.props.onChange(this.props.entity, this.props.componentname, this.props.name, value);
+        this.props.onChange(this.props.name, value);
       }
       this.setValue(value);
     });

--- a/src/components/widgets/Vec2Widget.js
+++ b/src/components/widgets/Vec2Widget.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import NumberWidget from './NumberWidget';
 
-export default class Vec3Widget extends React.Component {
+export default class Vec2Widget extends React.Component {
   static propTypes = {
     componentname: React.PropTypes.string,
     entity: React.PropTypes.object,
@@ -14,8 +14,7 @@ export default class Vec3Widget extends React.Component {
     super(props);
     this.state = {
       x: props.value.x,
-      y: props.value.y,
-      z: props.value.z
+      y: props.value.y
     };
   }
 
@@ -39,10 +38,9 @@ export default class Vec3Widget extends React.Component {
     };
 
     return (
-      <div className='vec3'>
+      <div className='vec2'>
         <NumberWidget name='x' value={this.state.x} {...widgetProps}/>
         <NumberWidget name='y' value={this.state.y} {...widgetProps}/>
-        <NumberWidget name='z' value={this.state.z} {...widgetProps}/>
       </div>
     );
   }

--- a/src/components/widgets/index.js
+++ b/src/components/widgets/index.js
@@ -5,5 +5,6 @@ module.exports = {
   NumberWidget: require('./NumberWidget').default,
   SelectWidget: require('./SelectWidget').default,
   TextureWidget: require('./TextureWidget').default,
-  Vec3Widget: require('./Vec3Widget').default
+  Vec3Widget: require('./Vec3Widget').default,
+  Vec2Widget: require('./Vec2Widget').default
 };

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -259,10 +259,12 @@ body.editor-opened {
   overflow: auto;
 }
 
+div.vec2,
 div.vec3 {
   display: inline;
 }
 
+.vec2 input.number,
 .vec3 input.number {
   width: 46px;
 }


### PR DESCRIPTION
While implementing it I found a bug that prevents the compound widgets like `vec3` to work properly outside of a single property component (Like `position`, `rotation`, ...).

I simplified the `updateEntity` function (Probably it will be a good idea to open an issue/PR on aframe to use it or modify `AFRAME.utils.entity.setComponentProperty` to accept `null/undefined` value.

I simplified the `onChange` callback on each widget as is not necessary anything else than the `value` and actually the `attribute name` (x,y,z,...) for compounds widgets.

I was thinking about leaving the tests for another PR as I'm not that familiar with this test system and as this is broken right now so we could get it working and then focus on testing side?
