### PR TITLE
Fix overlap right sidebar in to canvas

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -758,7 +758,6 @@ a.help-link:hover {
   align-items: stretch;
   position: fixed;
   top: 0;
-  bottom: 0;
   right: 0;
 }
 


### PR DESCRIPTION
Fix issue #304 
- Remove `bottom: 0;` at css rule _#right-panels_
