### PR TITLE
simplify inspector usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,13 @@ A visual inspector tool for [A-Frame](https://aframe.io) scenes. Just hit
 
 ## Using the Inspector
 
-There are several ways to use the inspector on your scene.
-
-### A-Frame Component
-
-A-Frame comes with a component to inject the inspector. Just open up any
-A-Frame scene (running at least A-Frame v0.3.0) and press **`<ctrl> + <alt> + i`** to
-inject the inspector, just like you would use a DOM inspector:
+A-Frame comes with a **keyboard shortcut** to inject the inspector. Just open
+up any A-Frame scene (running at least A-Frame v0.3.0) and press **`<ctrl> +
+<alt> + i`** to inject the inspector, just like you would use a DOM inspector:
 
 This is done with the `inspector` component. By default, this is set on the
-scene. We can specify which build of the Inspector to inject by passing a URL.
+scene already. If we want, we can specify a specific build of the Inspector to
+inject by passing a URL.
 
 ```html
 <a-scene inspector="url: https://aframe.io/releases/0.3.0/aframe-inspector.min.js">
@@ -29,28 +26,7 @@ scene. We can specify which build of the Inspector to inject by passing a URL.
 </a-scene>
 ```
 
-### Bookmarklet
-
-Copy and paste the code from the [bookmarket](bookmarklet) into a browser bookmark. Then
-open up any scene and click on the bookmarklet to inject the inspector.
-
-### Including the Build
-
-1. [Download the build](https://aframe.io/aframe-inspector/build/aframe-inspector.js)
-2. Add the build to the bottom of your A-Frame scene:
-
-```html
-<html>
-  <body>
-    <a-scene></a-scene>
-
-    <!-- Add the inspector build below the scene markup. -->
-    <script src="js/aframe-inspector.js"></script>
-  </body>
-</html>
-```
-
-## Working on the Inspector
+## Local Development
 
 ```bash
 git clone git@github.com:aframevr/aframe-inspector.git


### PR DESCRIPTION
Promote the keyboard shortcut as the primary way to use the Inspector by reducing other clutter instructions. Some people glossed over the shortcut and were reading about including a build.
