### PR TITLE
Fixes #312 Copy HTML

### DIFF
--- a/src/actions/component.js
+++ b/src/actions/component.js
@@ -32,7 +32,8 @@ function getModifiedProperties (entity, componentName) {
  */
 export function getClipboardRepresentation (entity, componentName) {
   var diff = getModifiedProperties(entity, componentName);
-  return AFRAME.utils.styleParser.stringify(diff);
+  var attributes = AFRAME.utils.styleParser.stringify(diff).replace(/;|:/g, '$& ');
+  return `${componentName}="${attributes}"`;
 }
 
 /**

--- a/src/components/components/Component.js
+++ b/src/components/components/Component.js
@@ -109,7 +109,7 @@ export default class Component extends React.Component {
             <a title='Copy to clipboard' data-action='copy-component-to-clipboard'
               data-component={subComponentName || componentName}
               className='flat-button' onClick={event => event.stopPropagation()}>
-              Copy HTML
+              Copy Attributes
             </a>
             <a title='Remove component' className='flat-button'
               onClick={this.removeComponent}>Remove</a>


### PR DESCRIPTION
As proposed in https://github.com/aframevr/aframe-inspector/issues/312:
* Replaced `Copy HTML` with `Copy attributes`
* Added spaces after `;` and `:` to make it easier to read:
  * before: `primitive:cylinder;height:0.2;radius:12`
  * now: `primitive: cylinder; height: 0.2; radius: 12`
* Added component's name and double quotes to the output: 
  * before: `primitive:cylinder;height:0.2;radius:12`
  * now: `geometry="primitive: cylinder; height: 0.2; radius: 12"`