### PR TITLE
Fix #320 force zoom:reset on a-scene canvas

### DIFF
--- a/example/embedded-zoom.html
+++ b/example/embedded-zoom.html
@@ -21,7 +21,7 @@
   <body>
     <div style="bottom: 0; left: 0; margin: 0 auto; right: 0; position: absolute; top: 0; width: 960px; zoom: 1.1">
       <div style="height: 480px; width: 640px">
-        <a-scene embedded inspector="url: ../build/aframe-inspector.js">
+        <a-scene embedded inspector="url: ../dist/aframe-inspector.js">
           <a-assets>
             <a-mixin id="blue" material="color: #4CC3D9"></a-mixin>
             <a-mixin id="blueBox" geometry="primitive: box; depth: 2; height: 5; width: 1" material="color: #4CC3D9"></a-mixin>

--- a/example/embedded.html
+++ b/example/embedded.html
@@ -24,7 +24,7 @@
     </style>
   </head>
   <body>
-    <a-scene embedded inspector="url: ../build/aframe-inspector.js">
+    <a-scene embedded inspector="url: ../dist/aframe-inspector.js">
       <a-assets>
         <a-mixin id="blue" material="color: #4CC3D9"></a-mixin>
         <a-mixin id="blueBox" geometry="primitive: box; depth: 2; height: 5; width: 1" material="color: #4CC3D9"></a-mixin>

--- a/example/empty.html
+++ b/example/empty.html
@@ -8,6 +8,6 @@
   <body>
     <a-scene stats>
     </a-scene>
-    <script src="http://localhost:3333/build/aframe-inspector.js"></script>
+    <script src="http://localhost:3333/dist/aframe-inspector.js"></script>
   </body>
 </html>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -774,6 +774,7 @@ a.help-link:hover {
   background-color: #191919;
   position: fixed;
   z-index: 9999;
+  zoom: reset;
 }
 
 span.entity-name {


### PR DESCRIPTION
Using `zoom: reset` on a-canvas, it will ignore previously defined zoom.
I've changed the example name from `embedded-bad` to  `embedded-zoom` :)