### PR TITLE
Adding support for editing a `vec4` type in the inspector

### DIFF
--- a/src/components/components/PropertyRow.js
+++ b/src/components/components/PropertyRow.js
@@ -7,6 +7,7 @@ import InputWidget from '../widgets/InputWidget';
 import NumberWidget from '../widgets/NumberWidget';
 import SelectWidget from '../widgets/SelectWidget';
 import TextureWidget from '../widgets/TextureWidget';
+import Vec4Widget from '../widgets/Vec4Widget';
 import Vec3Widget from '../widgets/Vec3Widget';
 import Vec2Widget from '../widgets/Vec2Widget';
 import {updateEntity} from '../../actions/entity';
@@ -75,6 +76,9 @@ export default class PropertyRow extends React.Component {
       }
       case 'vec3': {
         return <Vec3Widget {...widgetProps}/>;
+      }
+      case 'vec4': {
+        return <Vec4Widget {...widgetProps}/>;
       }
       case 'color': {
         return <ColorWidget {...widgetProps}/>;

--- a/src/components/widgets/Vec4Widget.js
+++ b/src/components/widgets/Vec4Widget.js
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import NumberWidget from './NumberWidget';
+
+export default class Vec4Widget extends React.Component {
+  static propTypes = {
+    componentname: React.PropTypes.string,
+    entity: React.PropTypes.object,
+    onChange: React.PropTypes.func,
+    value: React.PropTypes.object.isRequired
+  };
+
+  constructor (props) {
+    super(props);
+    this.state = {
+      x: props.value.x,
+      y: props.value.y,
+      z: props.value.z,
+      w: props.value.w
+    };
+  }
+
+  onChange = (name, value) => {
+    this.setState({[name]: value}, () => {
+      if (this.props.onChange) {
+        this.props.onChange(name, this.state);
+      }
+    });
+  }
+
+  componentWillReceiveProps (nextProps) {
+    this.setState(nextProps.value);
+  }
+
+  render () {
+    const widgetProps = {
+      componentname: this.props.componentname,
+      entity: this.props.entity,
+      onChange: this.onChange
+    };
+
+    return (
+      <div className='vec4'>
+        <NumberWidget name='x' value={this.state.x} {...widgetProps}/>
+        <NumberWidget name='y' value={this.state.y} {...widgetProps}/>
+        <NumberWidget name='z' value={this.state.z} {...widgetProps}/>
+        <NumberWidget name='w' value={this.state.w} {...widgetProps}/>
+      </div>
+    );
+  }
+}

--- a/src/components/widgets/index.js
+++ b/src/components/widgets/index.js
@@ -5,6 +5,7 @@ module.exports = {
   NumberWidget: require('./NumberWidget').default,
   SelectWidget: require('./SelectWidget').default,
   TextureWidget: require('./TextureWidget').default,
+  Vec4Widget: require('./Vec4Widget').default,
   Vec3Widget: require('./Vec3Widget').default,
   Vec2Widget: require('./Vec2Widget').default
 };

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -258,12 +258,14 @@ input[type=color]::-moz-focus-inner {
 }
 
 div.vec2,
-div.vec3 {
+div.vec3,
+div.vec4, {
   display: inline;
 }
 
 .vec2 input.number,
-.vec3 input.number {
+.vec3 input.number,
+.vec4 input.number {
   width: 46px;
 }
 


### PR DESCRIPTION
When trying to view and alter a `vec4` typed Quaternion component I had created I realized there wasn't a corresponding `PropertyRow` widget available.