### PR TITLE
Do not autofocus the AddComponent select field when first mounted

### DIFF
--- a/src/components/components/AddComponent.js
+++ b/src/components/components/AddComponent.js
@@ -96,7 +96,6 @@ export default class AddComponent extends React.Component {
           <Select
             className="add-component"
             ref="select"
-            autofocus
             options={this.options}
             simpleValue
             clearable={true}


### PR DESCRIPTION
When the AddComponent view is first mounted (when selecting an entity when there was no previously selected entity), its Select component takes focus, causing any attempted hotkey usage to enter in the Select component. Most likely necessary for any fixes for #406. Often when selecting an entity I'm more likely to transform than add a component -- but others may have different use cases in which this is needed, in which case, please close!