### PR TITLE
Do not fire hotkey commands based off of active element, but prevent

### DIFF
--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -1,7 +1,12 @@
 /* globals AFRAME */
 var Events = require('./Events');
-var shouldCaptureKeyEvent = AFRAME.utils.shouldCaptureKeyEvent;
 import {removeSelectedEntity, cloneSelectedEntity} from '../actions/entity';
+
+function shouldCaptureKeyEvent (event) {
+  if (event.metaKey) { return false; }
+  return event.target.tagName !== 'INPUT' &&
+    event.target.tagName !== 'TEXTAREA';
+}
 
 module.exports = {
   onKeyUp: function (event) {


### PR DESCRIPTION
input elements from propagating events to document if they should not be
acted on. Fixes #406