### PR TITLE
Set zoom:1 to canvas

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -774,7 +774,7 @@ a.help-link:hover {
   background-color: #191919;
   position: fixed;
   z-index: 9999;
-  zoom: reset;
+  zoom: 1;
 }
 
 span.entity-name {


### PR DESCRIPTION
It should fix the issues (https://github.com/aframevr/aframe-inspector/issues/402) with chrome zoom on HDPI Windows (`devicePixelRatio=1`).
I've tried the default example and the `embedded.html` on a windows with `pixelRatio=2` and `pixelRatio=1` and it's working.
Could you give it a try @ngokevin @kfarr @nucliweb ? 