### PR TITLE
Added Keyboard events to modify the values of rotation, translation and scaling using keyboard

### DIFF
--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -2,6 +2,16 @@
 var Events = require('./Events');
 import {removeSelectedEntity, cloneSelectedEntity} from '../actions/entity';
 
+AFRAME.Keyevents = {};
+AFRAME.Keyevents.VAL = null;
+AFRAME.Keyevents.DIM = 'x';
+AFRAME.Keyevents.LASTKEY = null;
+AFRAME.Keyevents.NEGATION = false;
+
+document.addEventListener("click", function(){
+  AFRAME.Keyevents.LASTKEY = null;
+});
+
 function shouldCaptureKeyEvent (event) {
   if (event.metaKey) { return false; }
   return event.target.tagName !== 'INPUT' &&
@@ -11,7 +21,6 @@ function shouldCaptureKeyEvent (event) {
 module.exports = {
   onKeyUp: function (event) {
     if (!shouldCaptureKeyEvent(event)) { return; }
-
     // h: help
     if (event.keyCode === 72) {
       Events.emit('openhelpmodal');
@@ -57,6 +66,49 @@ module.exports = {
     if (event.keyCode === 68) {
       cloneSelectedEntity();
     }
+
+    if(event.keyCode >=48 && event.keyCode<=57) {
+      if(AFRAME.Keyevents.VAL == null) {
+        AFRAME.Keyevents.VAL = 0;
+      }
+      AFRAME.Keyevents.VAL *= 10;
+      AFRAME.Keyevents.VAL += (event.keyCode - 48);
+    } else if(event.keyCode != 13 && event.keyCode != 189) {
+      AFRAME.Keyevents.VAL = null;
+      AFRAME.Keyevents.NEGATION = false;
+    }
+
+    if(event.keyCode == 13) {
+      var key = AFRAME.Keyevents.LASTKEY;
+      if(key === 88 || key === 89 || key === 90 || (key>=48 & key<=57)) {
+        if(AFRAME.Keyevents.NEGATION) {
+          Events.emit('modifyValue', { val: -1 * AFRAME.Keyevents.VAL,  dimension: AFRAME.Keyevents.DIM});
+        } else {
+          Events.emit('modifyValue', { val: AFRAME.Keyevents.VAL,  dimension: AFRAME.Keyevents.DIM});
+        }
+      }
+      AFRAME.Keyevents.VAL = null;
+      AFRAME.Keyevents.NEGATION = false;
+    }
+
+    if(event.keyCode == 189) {
+      if(AFRAME.Keyevents.VAL == null) {
+        AFRAME.Keyevents.NEGATION = true;
+      }
+    }
+
+    if (event.keyCode === 88) {
+    AFRAME.Keyevents.DIM = 'x';
+    }
+
+    if (event.keyCode === 89) {
+    AFRAME.Keyevents.DIM = 'y';
+    }
+
+    if (event.keyCode === 90) {
+    AFRAME.Keyevents.DIM = 'z';
+    }
+    AFRAME.Keyevents.LASTKEY = event.keyCode;
   },
   enable: function () {
     window.addEventListener('keyup', this.onKeyUp, false);

--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -67,6 +67,7 @@ module.exports = {
       cloneSelectedEntity();
     }
 
+    // Num Key from 1-9 pressed
     if(event.keyCode >=48 && event.keyCode<=57) {
       if(AFRAME.Keyevents.VAL == null) {
         AFRAME.Keyevents.VAL = 0;
@@ -78,13 +79,18 @@ module.exports = {
       AFRAME.Keyevents.NEGATION = false;
     }
 
+    // Return: Change value of specified direction
     if(event.keyCode == 13) {
       var key = AFRAME.Keyevents.LASTKEY;
       if(key === 88 || key === 89 || key === 90 || (key>=48 & key<=57)) {
         if(AFRAME.Keyevents.NEGATION) {
-          Events.emit('modifyValue', { val: -1 * AFRAME.Keyevents.VAL,  dimension: AFRAME.Keyevents.DIM});
+          if (AFRAME.INSPECTOR.selectedEntity) {
+            Events.emit('modifyValue', { val: -1 * AFRAME.Keyevents.VAL,  dimension: AFRAME.Keyevents.DIM});
+          }
         } else {
-          Events.emit('modifyValue', { val: AFRAME.Keyevents.VAL,  dimension: AFRAME.Keyevents.DIM});
+          if (AFRAME.INSPECTOR.selectedEntity) {
+            Events.emit('modifyValue', { val: AFRAME.Keyevents.VAL,  dimension: AFRAME.Keyevents.DIM});
+          }
         }
       }
       AFRAME.Keyevents.VAL = null;
@@ -97,14 +103,17 @@ module.exports = {
       }
     }
 
+    // x: Change edit mode to x direction
     if (event.keyCode === 88) {
     AFRAME.Keyevents.DIM = 'x';
     }
 
+    // x: Change edit mode to y direction
     if (event.keyCode === 89) {
     AFRAME.Keyevents.DIM = 'y';
     }
 
+    // z: Change edit mode to z direction
     if (event.keyCode === 90) {
     AFRAME.Keyevents.DIM = 'z';
     }

--- a/src/lib/viewport/index.js
+++ b/src/lib/viewport/index.js
@@ -307,6 +307,20 @@ function Viewport (inspector) {
     }
   });
 
+  Events.on('modifyValue', prop => {
+    var entity = AFRAME.INSPECTOR.selectedEntity;
+    var mode = transformControls.getMode();
+      if(transformControls.getMode() == "translate") {
+        mode = "position";
+      } else if (transformControls.getMode() == "rotate") {
+        mode = "rotation";
+      }
+      var value = entity.getAttribute(mode);
+      value[prop.dimension] = prop.val;
+      entity.setAttribute(mode, value);
+      Events.emit('objectchanged', entity.object3D);
+    });
+
   Events.on('objectfocused', object => {
     controls.focus(object);
     ga('send', 'event', 'Viewport', 'selectEntity');


### PR DESCRIPTION
It is a common shortcut in softwares like blender to change the transform properties in the three dimensions using the keyboard.
This P.R. implements the same.

If you press 'r', you go to the scaling mode. Now pressing 'x' followed by a numerical value modifies the scale in the x direction to that value on pressing enter.

Similarly for other transform properties and dimensions.