### PR TITLE
Fixes some bug in the copy&paste implementation

### DIFF
--- a/src/components/widgets/TextureWidget.js
+++ b/src/components/widgets/TextureWidget.js
@@ -84,6 +84,7 @@ export default class TextureWidget extends React.Component {
 
   componentWillReceiveProps (newProps) {
     var component = this.props.entity.components[this.props.componentname];
+    if (!component) { return; }
     var newValue = component.attrValue[this.props.name];
 
     // This will be triggered typically when the element is changed directly with element.setAttribute

--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -1,6 +1,7 @@
 /* globals AFRAME */
 var Events = require('./Events');
 import {removeSelectedEntity, cloneSelectedEntity, cloneEntity} from '../actions/entity';
+import {os} from '../lib/utils.js';
 
 function shouldCaptureKeyEvent (event) {
   if (event.metaKey) { return false; }
@@ -57,24 +58,32 @@ module.exports = {
     if (event.keyCode === 68) {
       cloneSelectedEntity();
     }
-
   },
   onKeyDown: function (event) {
     // c: copy selected entity
     if (event.keyCode === 67) {
-      if(AFRAME.INSPECTOR.selected && (event.ctrlKey || event.metaKey) && document.activeElement.tagName !== "INPUT") {
-        AFRAME.INSPECTOR.copiedEntity = AFRAME.INSPECTOR.selectedEntity;
+      if (AFRAME.INSPECTOR.selectedEntity &&
+        (event.ctrlKey && os === 'windows' || event.metaKey && os === 'macos') &&
+        document.activeElement.tagName !== 'INPUT') {
+        AFRAME.INSPECTOR.entityToCopy = AFRAME.INSPECTOR.selectedEntity;
       }
     }
 
     // v: paste copied entity
     if (event.keyCode === 86) {
-      if(AFRAME.INSPECTOR.copiedEntity && (event.ctrlKey || event.metaKey) && document.activeElement.tagName !== "INPUT") {
-        cloneEntity(AFRAME.INSPECTOR.copiedEntity);
+      if (AFRAME.INSPECTOR.entityToCopy &&
+        (event.ctrlKey && os === 'windows' || event.metaKey && os === 'macos') &&
+        document.activeElement.tagName !== 'INPUT') {
+        cloneEntity(AFRAME.INSPECTOR.entityToCopy);
       }
     }
   },
   enable: function () {
+    document.querySelector('a-scene').addEventListener('child-detached', event => {
+      if (event.detail.el === AFRAME.INSPECTOR.entityToCopy) {
+        AFRAME.INSPECTOR.entityToCopy = null;
+      }
+    });
     window.addEventListener('keyup', this.onKeyUp, false);
     window.addEventListener('keydown', this.onKeyDown, false);
   },

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -31,8 +31,32 @@ function equal (var1, var2) {
   return true;
 }
 
+function getOS () {
+  var userAgent = window.navigator.userAgent;
+  var platform = window.navigator.platform;
+  var macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
+  var windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
+  var iosPlatforms = ['iPhone', 'iPad', 'iPod'];
+  var os = null;
+
+  if (macosPlatforms.indexOf(platform) !== -1) {
+    os = 'macos';
+  } else if (iosPlatforms.indexOf(platform) !== -1) {
+    os = 'ios';
+  } else if (windowsPlatforms.indexOf(platform) !== -1) {
+    os = 'windows';
+  } else if (/Android/.test(userAgent)) {
+    os = 'android';
+  } else if (!os && /Linux/.test(platform)) {
+    os = 'linux';
+  }
+
+  return os;
+}
 module.exports = {
   equal: equal,
   getNumber: getNumber,
-  getMajorVersion: getMajorVersion
+  getMajorVersion: getMajorVersion,
+  getOS: getOS,
+  os: getOS()
 };


### PR DESCRIPTION
Just a few changes to the @vershwal implementation:
- It prevent to use both CMD and CTRL in mac to copy and paste, it just check the current OS and activate CMD for macos or CTRL for windows.
- Prevents to paste a deleted element.