### PR TITLE
fixing the active camera on saving

### DIFF
--- a/src/components/scenegraph/Toolbar.js
+++ b/src/components/scenegraph/Toolbar.js
@@ -28,6 +28,8 @@ export default class Toolbar extends React.Component {
       // URL.revokeObjectURL(url); breaks Firefox...
     }
     function saveString (text, filename) {
+      text = text.replace("active:true", "active:false")
+      text = text.replace('camera="active:false"', 'camera="active:true"')
       save(new Blob([ text ], { type: 'text/html' }), filename);
     }
     var sceneName = getSceneName(document.querySelector('a-scene'));


### PR DESCRIPTION
Currently the active camera is the editor yet, once saved, the editor is not opened hence showing a grey page without content (cf #433 ). This PR switches the active camera from editor camera to main camera.