### PR TITLE
Toggle panels

### DIFF
--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -24,12 +24,33 @@ injectCSS('https://fonts.googleapis.com/css?family=Roboto:400,300,500');
 export default class Main extends React.Component {
   constructor (props) {
     super(props);
+
     this.state = {
       inspectorEnabled: true,
       sceneEl: document.querySelector('a-scene'),
       entity: null,
-      isModalTexturesOpen: false
+      isModalTexturesOpen: false,
+      visible: {
+        scenegraph: true,
+        attributes: true
+      }
     };
+
+    Events.on('togglesidebar', event => {
+      if (event.which == 'all') {
+        if (this.state.visible.scenegraph || this.state.visible.attributes) {
+          this.state.visible.scenegraph = this.state.visible.attributes = false;
+        } else {
+          this.state.visible.scenegraph = this.state.visible.attributes = true;
+        }
+      } else if (event.which == 'attributes') {
+        this.state.visible.attributes = !this.state.visible.attributes;
+      } else if (event.which == 'scenegraph') {
+        this.state.visible.scenegraph = !this.state.visible.scenegraph;
+      }
+      this.forceUpdate();
+
+    });
   }
 
   componentDidMount () {
@@ -83,16 +104,20 @@ export default class Main extends React.Component {
   render () {
     var scene = this.state.sceneEl;
     let editButton = <a className='toggle-edit' onClick={this.toggleEdit}>{(this.state.inspectorEnabled ? 'Back to Scene' : 'Inspect Scene')}</a>;
+    const showScenegraph = this.state.visible.scenegraph ? null : <div className="toggle-sidebar left"><a onClick={() => {this.state.visible.scenegraph = true; this.forceUpdate()}} className='fa fa-plus' title='Show scenegraph'></a></div>;
+    const showAttributes = !this.state.entity || this.state.visible.attributes ? null : <div className="toggle-sidebar right"><a onClick={() => {this.state.visible.attributes = true; this.forceUpdate()}} className='fa fa-plus' title='Show components'></a></div>;
 
     return (
       <div>
         {editButton}
         <div id='aframe-inspector-panels' className={this.state.inspectorEnabled ? '' : 'hidden'}>
           <ModalTextures ref='modaltextures' isOpen={this.state.isModalTexturesOpen} selectedTexture={this.state.selectedTexture} onClose={this.onModalTextureOnClose}/>
-          <SceneGraph id='left-sidebar' scene={scene} selectedEntity={this.state.entity}/>
+          <SceneGraph id='left-sidebar' scene={scene} selectedEntity={this.state.entity} visible={this.state.visible.scenegraph}/>
+          {showScenegraph}
+          {showAttributes}
           <div id='right-panels'>
             <ToolBar/>
-            <ComponentsSidebar entity={this.state.entity}/>
+            <ComponentsSidebar entity={this.state.entity} visible={this.state.visible.attributes}/>
           </div>
         </div>
         <ModalHelp isOpen={this.state.isHelpOpen} onClose={this.onCloseHelpModal}/>

--- a/src/components/components/Sidebar.js
+++ b/src/components/components/Sidebar.js
@@ -4,24 +4,16 @@ import Events from '../../lib/Events';
 
 export default class Sidebar extends React.Component {
   static propTypes = {
-    entity: React.PropTypes.object
+    entity: React.PropTypes.object,
+    visible: React.PropTypes.bool
   };
 
   constructor (props) {
     super(props);
     this.state = {
       open: false,
-      visible: true,
       entity: props.entity
     };
-
-    Events.on('togglesidebar', event => {
-      if (event.which == 'all' || event.which == 'sidebar') {
-        this.state.visible = ! this.state.visible;
-        this.forceUpdate();
-      }
-    });
-
   }
 
   componentDidMount () {
@@ -59,7 +51,7 @@ export default class Sidebar extends React.Component {
 
   render () {
     const entity = this.state.entity;
-    const visible = this.state.visible;
+    const visible = this.props.visible;
     if (entity && visible) {
       return (
         <div id='sidebar'>

--- a/src/components/components/Sidebar.js
+++ b/src/components/components/Sidebar.js
@@ -11,8 +11,17 @@ export default class Sidebar extends React.Component {
     super(props);
     this.state = {
       open: false,
+      visible: true,
       entity: props.entity
     };
+
+    Events.on('togglesidebar', event => {
+      if (event.which == 'all' || event.which == 'sidebar') {
+        this.state.visible = ! this.state.visible;
+        this.forceUpdate();
+      }
+    });
+
   }
 
   componentDidMount () {
@@ -50,7 +59,8 @@ export default class Sidebar extends React.Component {
 
   render () {
     const entity = this.state.entity;
-    if (entity) {
+    const visible = this.state.visible;
+    if (entity && visible) {
       return (
         <div id='sidebar'>
           <ComponentsContainer entity={this.state.entity}/>

--- a/src/components/modals/ModalHelp.js
+++ b/src/components/modals/ModalHelp.js
@@ -38,6 +38,10 @@ export default class ModalHelp extends React.Component {
         {key: ['supr | backspace'], description: 'Delete selected entity'}
       ],
       [
+        {key: ['1'], description: 'Toggle scenegraph panel'},
+        {key: ['2'], description: 'Toggle components panel'},
+        {key: ['tab'], description: 'Toggle scenegraph and components panel'},
+
         {key: ['ctrl | cmd', 'x'], description: 'Cut selected entity'},
         {key: ['ctrl | cmd', 'c'], description: 'Copy selected entity'},
         {key: ['ctrl | cmd', 'v'], description: 'Paste entity'},

--- a/src/components/scenegraph/SceneGraph.js
+++ b/src/components/scenegraph/SceneGraph.js
@@ -35,8 +35,10 @@ export default class SceneGraph extends React.Component {
       value: this.props.value || '',
       options: [],
       selectedIndex: -1,
-      filterText: ''
+      filterText: '',
+      visible: true
     };
+
   }
 
   componentDidMount () {
@@ -53,6 +55,14 @@ export default class SceneGraph extends React.Component {
     Events.on('entityidchanged', this.rebuildOptions);
     document.addEventListener('componentremoved', this.rebuildOptions);
     Events.on('dommodified', this.rebuildOptions);
+
+
+    Events.on('togglesidebar', event => {
+      if (event.which == 'all' || event.which == 'scenegraph') {
+        this.state.visible = ! this.state.visible;
+        this.forceUpdate();
+      }
+    });
   }
 
   setValue = value => {
@@ -255,6 +265,14 @@ export default class SceneGraph extends React.Component {
   }
 
   render () {
+    // to hide the SceneGraph we have to hide its parent too (#left-sidebar)
+    var leftsidebar = document.getElementById('left-sidebar');
+    if (leftsidebar) leftsidebar.style.display = this.state.visible ? 'flex' : 'none';
+
+    if (!this.state.visible) {
+      return null;
+    }
+
     let clearFilter = this.state.filterText ? <a onClick={this.clearFilter} className='button fa fa-times'></a> : null;
 
     return (

--- a/src/components/scenegraph/SceneGraph.js
+++ b/src/components/scenegraph/SceneGraph.js
@@ -20,7 +20,8 @@ export default class SceneGraph extends React.Component {
   static propTypes = {
     onChange: React.PropTypes.func,
     scene: React.PropTypes.object,
-    value: React.PropTypes.string
+    value: React.PropTypes.string,
+    visible: React.PropTypes.bool
   };
 
   static defaultProps = {
@@ -35,8 +36,7 @@ export default class SceneGraph extends React.Component {
       value: this.props.value || '',
       options: [],
       selectedIndex: -1,
-      filterText: '',
-      visible: true
+      filterText: ''
     };
 
   }
@@ -55,14 +55,6 @@ export default class SceneGraph extends React.Component {
     Events.on('entityidchanged', this.rebuildOptions);
     document.addEventListener('componentremoved', this.rebuildOptions);
     Events.on('dommodified', this.rebuildOptions);
-
-
-    Events.on('togglesidebar', event => {
-      if (event.which == 'all' || event.which == 'scenegraph') {
-        this.state.visible = ! this.state.visible;
-        this.forceUpdate();
-      }
-    });
   }
 
   setValue = value => {
@@ -266,10 +258,7 @@ export default class SceneGraph extends React.Component {
 
   render () {
     // to hide the SceneGraph we have to hide its parent too (#left-sidebar)
-    var leftsidebar = document.getElementById('left-sidebar');
-    if (leftsidebar) leftsidebar.style.display = this.state.visible ? 'flex' : 'none';
-
-    if (!this.state.visible) {
+    if (!this.props.visible) {
       return null;
     }
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1110,3 +1110,31 @@ span.entity-name {
 .outliner .option .icons a.button {
   color: #fff;
 }
+
+.toggle-sidebar {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  position: absolute;
+  z-index: 9998;
+}
+
+.toggle-sidebar.left {
+  left: 0;
+}
+
+.toggle-sidebar.right {
+  right: 0;
+}
+
+.toggle-sidebar a {
+  background-color: #262626;
+  color: #bcbcbc;
+  padding: 5px;
+  z-index: 9998;
+}
+
+.toggle-sidebar a:hover {
+  background-color: #1faaf2;
+  color: #fff;
+}

--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -10,27 +10,6 @@ function shouldCaptureKeyEvent (event) {
 }
 
 module.exports = {
-  onKeyDown: function (event) {
-    if (!shouldCaptureKeyEvent(event)) { return; }
-
-    // tab: toggle sidebars visibility
-    if (event.keyCode === 9) {
-      Events.emit('togglesidebar', {which:'all'});
-      event.preventDefault();
-      event.stopPropagation();
-    }
-
-    // 1: toggle scenegraph visibility only
-    if (event.keyCode === 49) {
-      Events.emit('togglesidebar', {which:'scenegraph'});
-    }
-
-    // 2: toggle sidebar visibility only
-    if (event.keyCode === 50) {
-      Events.emit('togglesidebar', {which:'sidebar'});
-    }
-  },
-
   onKeyUp: function (event) {
     if (!shouldCaptureKeyEvent(event)) { return; }
 
@@ -108,15 +87,29 @@ module.exports = {
         document.getElementById('filter').focus();
       }
     }
+    // tab: toggle sidebars visibility
+    if (event.keyCode === 9) {
+      Events.emit('togglesidebar', {which:'all'});
+      event.preventDefault();
+      event.stopPropagation();
+    }
+
+    // 1: toggle scenegraph visibility only
+    if (event.keyCode === 49) {
+      Events.emit('togglesidebar', {which:'scenegraph'});
+    }
+
+    // 2: toggle sidebar visibility only
+    if (event.keyCode === 50) {
+      Events.emit('togglesidebar', {which:'attributes'});
+    }
   },
   enable: function () {
     window.addEventListener('keydown', this.onKeyDown, false);
     window.addEventListener('keyup', this.onKeyUp, false);
-    window.addEventListener('keydown', this.onKeyDown, false);
   },
   disable: function () {
     window.removeEventListener('keydown', this.onKeyDown);
     window.removeEventListener('keyup', this.onKeyUp);
-    window.removeEventListener('keydown', this.onKeyDown);
   }
 };

--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -10,6 +10,27 @@ function shouldCaptureKeyEvent (event) {
 }
 
 module.exports = {
+  onKeyDown: function (event) {
+    if (!shouldCaptureKeyEvent(event)) { return; }
+
+    // tab: toggle sidebars visibility
+    if (event.keyCode === 9) {
+      Events.emit('togglesidebar', {which:'all'});
+      event.preventDefault();
+      event.stopPropagation();
+    }
+
+    // 1: toggle scenegraph visibility only
+    if (event.keyCode === 49) {
+      Events.emit('togglesidebar', {which:'scenegraph'});
+    }
+
+    // 2: toggle sidebar visibility only
+    if (event.keyCode === 50) {
+      Events.emit('togglesidebar', {which:'sidebar'});
+    }
+  },
+
   onKeyUp: function (event) {
     if (!shouldCaptureKeyEvent(event)) { return; }
 
@@ -89,10 +110,12 @@ module.exports = {
     }
   },
   enable: function () {
+    window.addEventListener('keydown', this.onKeyDown, false);
     window.addEventListener('keyup', this.onKeyUp, false);
     window.addEventListener('keydown', this.onKeyDown, false);
   },
   disable: function () {
+    window.removeEventListener('keydown', this.onKeyDown);
     window.removeEventListener('keyup', this.onKeyUp);
     window.removeEventListener('keydown', this.onKeyDown);
   }


### PR DESCRIPTION
Toggle panels using the keyboard:
- `1` to toggle scenegraph
- `2` to toggle the components' panel
- `tab` to toggle both

When we hide a panel, a `[ + ]` button will appear on that side to restore the visibility of that panel.
![image](https://cloud.githubusercontent.com/assets/782511/22887689/4c551304-f203-11e6-9afe-2261f9237497.png)
