### PR TITLE
Use a delimiter that isn't valid in NPM package names.

### DIFF
--- a/src/components/components/AddComponent.js
+++ b/src/components/components/AddComponent.js
@@ -4,6 +4,8 @@ var INSPECTOR = require('../../lib/inspector.js');
 import Select from 'react-select';
 import 'react-select/dist/react-select.css';
 
+var DELIMITER = ' ';
+
 export default class AddComponent extends React.Component {
   static propTypes = {
     entity: React.PropTypes.object
@@ -21,7 +23,7 @@ export default class AddComponent extends React.Component {
     })[0];
 
     if (selectedOption.origin === 'registry') {
-      [packageName, componentName] = selectedOption.value.split('.');
+      [packageName, componentName] = selectedOption.value.split(DELIMITER);
       INSPECTOR.componentLoader.addComponentToScene(packageName, componentName)
         .then(addComponent);
     } else {
@@ -70,7 +72,7 @@ export default class AddComponent extends React.Component {
       });
     var registryOptions = registryComponents
       .map(function (item) {
-        return {value: item.componentPackageName + '.' + item.componentName,
+        return {value: item.componentPackageName + DELIMITER + item.componentName,
           label: item.componentName, origin: 'registry'};
       });
 


### PR DESCRIPTION
The '.' character used by libraries like Lodash that publish sub-packages to NPM. I've taken the same pattern with `aframe-extras._____`, which is breaking here. [Spaces are invalid in NPM package names](https://github.com/npm/validate-npm-package-name#naming-rules) as well as component names, hence the choice.