### PR TITLE
Fixes #461 Non-visible entities are not selectable

### DIFF
--- a/src/lib/viewport/index.js
+++ b/src/lib/viewport/index.js
@@ -195,12 +195,25 @@ function Viewport (inspector) {
     if (onDownPosition.distanceTo(onUpPosition) === 0) {
       var intersects = getIntersects(onUpPosition, objects);
       if (intersects.length > 0) {
-        var object = intersects[ 0 ].object;
-        if (object.userData.object !== undefined) {
-          // helper
-          inspector.selectEntity(object.userData.object.el);
-        } else {
-          inspector.selectEntity(object.el);
+        var selected = false;
+        for (var i = 0; i < intersects.length; i++) {
+          var object = intersects[i].object;
+          if (!object.el.getAttribute('visible')) {
+            continue;
+          }
+
+          selected = true;
+
+          if (object.userData.object !== undefined) {
+            // helper
+            inspector.selectEntity(object.userData.object.el);
+          } else {
+            inspector.selectEntity(object.el);
+          }
+        }
+
+        if (!selected) {
+          inspector.selectEntity(null);
         }
       } else {
         inspector.selectEntity(null);


### PR DESCRIPTION
Non-visible entities are not selectable. But the boundingbox will be visible if you select them on the scenegraph.

![selectable](https://cloud.githubusercontent.com/assets/782511/24800001/7db1face-1b9e-11e7-93e0-2660ca349ee0.gif)
