### PR TITLE
Selection should select the object closest to the camera.

### DIFF
--- a/src/lib/viewport/index.js
+++ b/src/lib/viewport/index.js
@@ -210,6 +210,8 @@ function Viewport (inspector) {
           } else {
             inspector.selectEntity(object.el);
           }
+
+          break;
         }
 
         if (!selected) {


### PR DESCRIPTION
`raycaster.intersectObjects(objects)` returns intersections sorted by distance, closest first, according to the doc at https://threejs.org/docs/?q=Raycaster#Reference/Core/Raycaster

So, once we find a valid selection target, we should break the loop, because the later ones will be further away from the camera.