### PR TITLE
Avoiding setAttribute() side effects.

### DIFF
--- a/src/actions/entity.js
+++ b/src/actions/entity.js
@@ -177,6 +177,8 @@ function prepareForSerialization(entity) {
  * @param {Element} source Element to be optimized.
  */
 function optimizeComponents(copy, source) {
+  var removeAttribute = HTMLElement.prototype.removeAttribute;
+  var setAttribute = HTMLElement.prototype.setAttribute;
   var components = source.components || {};
   Object.keys(components).forEach(function (name) {
     var component = components[name];
@@ -187,10 +189,11 @@ function optimizeComponents(copy, source) {
     var optimalUpdate = getOptimalUpdate(component, implicitValue, currentValue);
     var doesNotNeedUpdate = optimalUpdate === null;
     if (isInherited && doesNotNeedUpdate) {
-      copy.removeAttribute(name);
+      removeAttribute.call(copy, name);
     }
     else {
-      copy.setAttribute(name, optimalUpdate, true);
+      var strValue = AFRAME.utils.styleParser.stringify(optimalUpdate || {});
+      setAttribute.call(copy, name, strValue);
     }
   });
 }


### PR DESCRIPTION
While optimizing components for the clipboard representation, calling
setAttribute() directly could have side effects on entity's components already
processed (such as re-setting properties already removed). To avoid side
effects, HTMLElement original setAttribute() and removeAttribute() functions are
used instead.