### PR TITLE
Exposes inspector events

### DIFF
--- a/src/lib/inspector.js
+++ b/src/lib/inspector.js
@@ -12,6 +12,7 @@ function Inspector () {
     gltf: new THREE.GLTFExporter()
   };
   this.modules = {};
+  this.on = Events.on;
   this.opened = false;
   // Detect if the scene is already loaded
   if (document.readyState === 'complete' || document.readyState === 'loaded') {


### PR DESCRIPTION
building scripts on top of the inspector i would like to be able to listen to inspector events i.e.
```javascript
AFRAME.INSPECTOR.on('inspectormodechanged', function(event){  })
```