### PR TITLE
Fix: clear filter button does not work #578

### DIFF
--- a/src/components/scenegraph/SceneGraph.js
+++ b/src/components/scenegraph/SceneGraph.js
@@ -244,6 +244,7 @@ export default class SceneGraph extends React.Component {
 
   clearFilter = () => {
     this.setState({ filter: '' });
+    this.updateFilteredEntities('');
   };
 
   renderEntities = () => {
@@ -288,6 +289,7 @@ export default class SceneGraph extends React.Component {
               placeholder="Search..."
               onChange={this.onChangeFilter}
               onKeyUp={this.onFilterKeyUp}
+              value={this.state.filter}
             />
             {clearFilter}
             {!this.state.filter && <span className="fa fa-search" />}


### PR DESCRIPTION
The clear filter button does not work in inspector 
Fixed the following
1. Cleared filter input box
2. Update filtered entity list 