### PR TITLE
fix when saving the scene with a-frame watcher and color is changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 4
+  - 8
 
 install:
   - npm install

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -8,7 +8,7 @@ import ModalTextures from './modals/ModalTextures';
 import ModalHelp from './modals/ModalHelp';
 import SceneGraph from './scenegraph/SceneGraph';
 import CameraToolbar from './viewport/CameraToolbar';
-import TransformToolBar from './viewport/TransformToolBar';
+import TransformToolbar from './viewport/TransformToolbar';
 import ViewportHUD from './viewport/ViewportHUD';
 import { injectCSS } from '../lib/utils';
 
@@ -172,7 +172,7 @@ export default class Main extends React.Component {
           <div id="viewportBar">
             <CameraToolbar />
             <ViewportHUD />
-            <TransformToolBar />
+            <TransformToolbar />
           </div>
 
           <div id="rightPanel">

--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -18,7 +18,9 @@ Events.on('entityupdate', payload => {
     if (payload.property) {
       updates[entity.id][payload.component] =
         updates[entity.id][payload.component] || {};
-      value = component.schema[payload.property].stringify(payload.value);
+      if (component.schema[payload.property]) {
+        value = component.schema[payload.property].stringify(payload.value);
+      }
       updates[entity.id][payload.component][payload.property] = value;
     } else {
       value = component.schema.stringify(payload.value);


### PR DESCRIPTION
I noticed when changing material color it wasn't being saved with aframe watcher due to an undefined in the `entityupdate` listener,  other material properties seemed to be ok. I didn't test all of them as color was main concern. 

Let me know if this is the best way to fix it.

previous payload when changing color:

`{"sphere1":{"position":"0 1.234885180247932 -5","material":{},"box1":{"material":{}}}`

now:

`{"sphere1":{"position":"0 1.234885180247932 -5","material":{"color":"#4494ef"}},"box1":{"material":{"color":"#d93336"}}}`

**Additions: fix CI build, I choose node 8 to be safe although can be changed to LTS 