### PR TITLE
Fix inspector toggle on US international keyboards

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ Inspector.prototype = {
   initEvents: function() {
     window.addEventListener('keydown', evt => {
       // Alt + Ctrl + i: Shorcut to toggle the inspector
-      var shortcutPressed = evt.keyCode === 73 && evt.ctrlKey && evt.altKey;
+      var shortcutPressed = evt.keyCode === 73 && (evt.ctrlKey && evt.altKey || evt.getModifierState('AltGraph'));
       if (shortcutPressed) {
         this.toggle();
       }


### PR DESCRIPTION
Fixes issue #595 
See also issue aframevr/aframe#4089

On US international keyboards Ctrl + Alt are combined into AltGraph. When this happens Ctrl and Alt are registered as unpressed, breaking the toggle expression

This is fixed by adding an additional clause for the AltGraph combination.