### PR TITLE
Some code cleanup

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
   "rules": {
     "react/jsx-indent-props": [2, 2],
     "semi": [2, "always"],
+    "space-before-function-paren": "off",
     "no-console": "off"
   },
   "env": {

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/lib/TransformControls.js

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "printWidth": 80,
+  "singleQuote": true
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
   "printWidth": 80,
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "none"
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lintfile": "node --harmony node_modules/.bin/eslint",
     "preghpages": "npm run dist && shx rm -rf gh-pages && shx mkdir gh-pages && shx cp -r assets dist examples index.html gh-pages && shx sed -i http://localhost:3333 .. gh-pages/examples/index.html",
     "prepublish": "npm run dist",
-    "prettier": "prettier --single-quote es5 --write 'src/**/*.js'",
+    "prettier": "prettier --write 'src/**/*.js'",
     "start": "cross-env NODE_ENV=dev webpack-dev-server --progress --colors -d --host 0.0.0.0",
     "test": "jest --watch",
     "test:ci": "jest"

--- a/src/components/Collapsible.js
+++ b/src/components/Collapsible.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 
 export default class Collapsible extends React.Component {
   static propTypes = {
+    className: PropTypes.string,
     collapsed: PropTypes.bool,
     children: PropTypes.oneOfType([PropTypes.array, PropTypes.element])
       .isRequired,

--- a/src/components/Collapsible.js
+++ b/src/components/Collapsible.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
+import classNames from 'classnames';
 
 export default class Collapsible extends React.Component {
   static propTypes = {
@@ -35,9 +35,9 @@ export default class Collapsible extends React.Component {
     if (this.props.className) {
       rootClassNames[this.props.className] = true;
     }
-    const rootClasses = classnames(rootClassNames);
+    const rootClasses = classNames(rootClassNames);
 
-    const contentClasses = classnames({
+    const contentClasses = classNames({
       content: true,
       hide: this.state.collapsed
     });

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 THREE.ImageUtils.crossOrigin = '';
 
-const Events = require('../lib/Events.js');
+import Events from '../lib/Events';
 import ComponentsSidebar from './components/Sidebar';
 import ModalTextures from './modals/ModalTextures';
 import ModalHelp from './modals/ModalHelp';

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -1,7 +1,4 @@
 import React from 'react';
-
-THREE.ImageUtils.crossOrigin = '';
-
 import Events from '../lib/Events';
 import ComponentsSidebar from './components/Sidebar';
 import ModalTextures from './modals/ModalTextures';
@@ -11,6 +8,8 @@ import CameraToolbar from './viewport/CameraToolbar';
 import TransformToolbar from './viewport/TransformToolbar';
 import ViewportHUD from './viewport/ViewportHUD';
 import { injectCSS } from '../lib/utils';
+
+THREE.ImageUtils.crossOrigin = '';
 
 // Megahack to include font-awesome.
 injectCSS('https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css');
@@ -89,6 +88,7 @@ export default class Main extends React.Component {
       this.setState({ isHelpOpen: true });
     });
   }
+
   onCloseHelpModal = value => {
     this.setState({ isHelpOpen: false });
   };

--- a/src/components/components/AddComponent.js
+++ b/src/components/components/AddComponent.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import Events from '../../lib/Events';
 import Select from 'react-select';
 
-var DELIMITER = ' ';
-
 export default class AddComponent extends React.Component {
   static propTypes = {
     entity: PropTypes.object
@@ -18,10 +16,6 @@ export default class AddComponent extends React.Component {
     let componentName = value.value;
 
     var entity = this.props.entity;
-    var packageName;
-    var selectedOption = this.options.filter(function(option) {
-      return option.value === componentName;
-    })[0];
 
     if (AFRAME.components[componentName].multiple) {
       const id = prompt(

--- a/src/components/components/AddComponent.js
+++ b/src/components/components/AddComponent.js
@@ -99,7 +99,7 @@ export default class AddComponent extends React.Component {
  */
 function isComponentInstanced(entity, componentName) {
   for (var component in entity.components) {
-    if (component.substr(0, component.indexOf('__')) === componentName) {
+    if (component.substring(0, component.indexOf('__')) === componentName) {
       return true;
     }
   }

--- a/src/components/components/CommonComponents.js
+++ b/src/components/components/CommonComponents.js
@@ -1,3 +1,4 @@
+/* global process */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { InputWidget } from '../widgets';

--- a/src/components/components/CommonComponents.js
+++ b/src/components/components/CommonComponents.js
@@ -55,7 +55,6 @@ export default class CommonComponents extends React.Component {
 
   renderCommonAttributes() {
     const entity = this.props.entity;
-    const components = entity ? entity.components : {};
     return ['position', 'rotation', 'scale', 'visible'].map(componentName => {
       const schema = AFRAME.components[componentName].schema;
       var data = entity.object3D[componentName];

--- a/src/components/components/Component.js
+++ b/src/components/components/Component.js
@@ -1,4 +1,3 @@
-/* global AFRAME */
 import React from 'react';
 import PropTypes from 'prop-types';
 import PropertyRow from './PropertyRow';

--- a/src/components/components/Mixins.js
+++ b/src/components/components/Mixins.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Select from 'react-select';
-
-const Events = require('../../lib/Events.js');
+import Events from '../../lib/Events';
 
 function trim(s) {
   s = s.replace(/(^\s*)|(\s*$)/gi, '');

--- a/src/components/components/Mixins.js
+++ b/src/components/components/Mixins.js
@@ -56,7 +56,6 @@ export default class Mixin extends React.Component {
 
     this.setState({ mixins: value });
     const mixinStr = value.map(v => v.value).join(' ');
-    console.log(mixinStr);
     entity.setAttribute('mixin', mixinStr);
 
     Events.emit('entityupdate', {

--- a/src/components/components/Mixins.js
+++ b/src/components/components/Mixins.js
@@ -3,13 +3,6 @@ import PropTypes from 'prop-types';
 import Select from 'react-select';
 import Events from '../../lib/Events';
 
-function trim(s) {
-  s = s.replace(/(^\s*)|(\s*$)/gi, '');
-  s = s.replace(/[ ]{2,}/gi, ' ');
-  s = s.replace(/\n /, '\n');
-  return s;
-}
-
 export default class Mixin extends React.Component {
   static propTypes = {
     entity: PropTypes.object.isRequired

--- a/src/components/components/PropertyRow.js
+++ b/src/components/components/PropertyRow.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-prototype-builtins */
 import React from 'react';
-import classnames from 'classnames';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
 import Events from '../../lib/Events';
@@ -121,7 +121,7 @@ export default class PropertyRow extends React.Component {
     const title =
       props.name + '\n - type: ' + props.schema.type + '\n - value: ' + value;
 
-    const className = classnames({
+    const className = classNames({
       propertyRow: true,
       propertyRowDefined: props.isSingle
         ? !!props.entity.getDOMAttribute(props.componentname)

--- a/src/components/components/PropertyRow.js
+++ b/src/components/components/PropertyRow.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-prototype-builtins */
 import React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';

--- a/src/components/components/PropertyRow.js
+++ b/src/components/components/PropertyRow.js
@@ -19,6 +19,7 @@ import { updateEntity } from '../../lib/entity';
 export default class PropertyRow extends React.Component {
   static propTypes = {
     componentname: PropTypes.string.isRequired,
+    entity: PropTypes.object.isRequired,
     id: PropTypes.string,
     name: PropTypes.string.isRequired,
     schema: PropTypes.object.isRequired

--- a/src/components/components/PropertyRow.js
+++ b/src/components/components/PropertyRow.js
@@ -19,8 +19,16 @@ import { updateEntity } from '../../lib/entity';
 export default class PropertyRow extends React.Component {
   static propTypes = {
     componentname: PropTypes.string.isRequired,
+    data: PropTypes.oneOfType([
+      PropTypes.array.isRequired,
+      PropTypes.bool.isRequired,
+      PropTypes.number.isRequired,
+      PropTypes.object.isRequired,
+      PropTypes.string.isRequired
+    ]),
     entity: PropTypes.object.isRequired,
     id: PropTypes.string,
+    isSingle: PropTypes.bool.isRequired,
     name: PropTypes.string.isRequired,
     schema: PropTypes.object.isRequired
   };

--- a/src/components/modals/Modal.js
+++ b/src/components/modals/Modal.js
@@ -1,4 +1,4 @@
-var React = require('react');
+import React from 'react';
 import PropTypes from 'prop-types';
 
 export default class Modal extends React.Component {

--- a/src/components/modals/Modal.js
+++ b/src/components/modals/Modal.js
@@ -48,8 +48,9 @@ export default class Modal extends React.Component {
     if (target.tagName === 'INPUT' && target.type === 'file') {
       return false;
     }
-    if (target === this.refs.self || this.refs.self.contains(target))
+    if (target === this.refs.self || this.refs.self.contains(target)) {
       return false;
+    }
     return true;
   };
 

--- a/src/components/modals/ModalTextures.js
+++ b/src/components/modals/ModalTextures.js
@@ -1,8 +1,8 @@
-import Events from '../../lib/Events';
 import React from 'react';
 import PropTypes from 'prop-types';
+import Events from '../../lib/Events';
 import Modal from './Modal';
-var insertNewAsset = require('../../lib/assetsUtils').insertNewAsset;
+import { insertNewAsset } from '../../lib/assetsUtils';
 
 function getFilename(url, converted = false) {
   var filename = url.split('/').pop();

--- a/src/components/modals/ModalTextures.js
+++ b/src/components/modals/ModalTextures.js
@@ -14,7 +14,7 @@ function getFilename(url, converted = false) {
 
 function isValidId(id) {
   // The correct re should include : and . but A-frame seems to fail while accessing them
-  var re = /^[A-Za-z]+[\w\-]*$/;
+  var re = /^[A-Za-z]+[\w-]*$/;
   return re.test(id);
 }
 

--- a/src/components/modals/ModalTextures.js
+++ b/src/components/modals/ModalTextures.js
@@ -122,7 +122,7 @@ export default class ModalTextures extends React.Component {
     var self = this;
     Array.prototype.slice
       .call(document.querySelectorAll('a-assets img'))
-      .map(asset => {
+      .forEach(asset => {
         var image = new Image();
         image.addEventListener('load', () => {
           self.state.assetsImages.push({

--- a/src/components/scenegraph/Entity.js
+++ b/src/components/scenegraph/Entity.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
+import classNames from 'classnames';
+import Events from '../../lib/Events';
 import { printEntity, removeEntity, cloneEntity } from '../../lib/entity';
-
-const Events = require('../../lib/Events.js');
 
 export default class Entity extends React.Component {
   static propTypes = {
@@ -91,7 +90,7 @@ export default class Entity extends React.Component {
     );
 
     // Class name.
-    const className = classnames({
+    const className = classNames({
       active: this.props.isSelected,
       entity: true,
       novisible: !visible,

--- a/src/components/scenegraph/Entity.js
+++ b/src/components/scenegraph/Entity.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-danger */
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';

--- a/src/components/scenegraph/SceneGraph.js
+++ b/src/components/scenegraph/SceneGraph.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-vars, react/no-danger */
 import PropTypes from 'prop-types';
 import React from 'react';
-import classnames from 'classnames';
 import debounce from 'lodash.debounce';
 
 import Entity from './Entity';

--- a/src/components/scenegraph/SceneGraph.js
+++ b/src/components/scenegraph/SceneGraph.js
@@ -5,7 +5,7 @@ import debounce from 'lodash.debounce';
 
 import Entity from './Entity';
 import Toolbar from './Toolbar';
-const Events = require('../../lib/Events.js');
+import Events from '../../lib/Events';
 
 export default class SceneGraph extends React.Component {
   static propTypes = {

--- a/src/components/scenegraph/Toolbar.js
+++ b/src/components/scenegraph/Toolbar.js
@@ -1,8 +1,8 @@
 /* global process */
-import classnames from 'classnames';
 import React from 'react';
-import Events from '../../lib/Events.js';
-import { saveBlob, saveString } from '../../lib/utils';
+import classNames from 'classnames';
+import Events from '../../lib/Events';
+import { saveBlob } from '../../lib/utils';
 
 function filterHelpers(scene, visible) {
   scene.traverse(o => {
@@ -91,7 +91,7 @@ export default class Toolbar extends React.Component {
   }
 
   render() {
-    const watcherClassNames = classnames({
+    const watcherClassNames = classNames({
       button: true,
       fa: true,
       'fa-save': true

--- a/src/components/scenegraph/Toolbar.js
+++ b/src/components/scenegraph/Toolbar.js
@@ -1,3 +1,4 @@
+/* global process */
 import classnames from 'classnames';
 import React from 'react';
 import Events from '../../lib/Events.js';

--- a/src/components/scenegraph/Toolbar.js
+++ b/src/components/scenegraph/Toolbar.js
@@ -26,8 +26,8 @@ function slugify(text) {
     .toString()
     .toLowerCase()
     .replace(/\s+/g, '-') // Replace spaces with -
-    .replace(/[^\w\-]+/g, '-') // Replace all non-word chars with -
-    .replace(/\-\-+/g, '-') // Replace multiple - with single -
+    .replace(/[^\w-]+/g, '-') // Replace all non-word chars with -
+    .replace(/--+/g, '-') // Replace multiple - with single -
     .replace(/^-+/, '') // Trim - from start of text
     .replace(/-+$/, ''); // Trim - from end of text
 }

--- a/src/components/scenegraph/Toolbar.js
+++ b/src/components/scenegraph/Toolbar.js
@@ -3,8 +3,6 @@ import React from 'react';
 import Events from '../../lib/Events.js';
 import { saveBlob, saveString } from '../../lib/utils';
 
-const LOCALSTORAGE_MOCAP_UI = 'aframeinspectormocapuienabled';
-
 function filterHelpers(scene, visible) {
   scene.traverse(o => {
     if (o.userData.source === 'INSPECTOR') {

--- a/src/components/viewport/CameraToolbar.js
+++ b/src/components/viewport/CameraToolbar.js
@@ -1,7 +1,6 @@
-var React = require('react');
-var Events = require('../../lib/Events.js');
-var classNames = require('classnames');
+import React from 'react';
 import Select from 'react-select';
+import Events from '../../lib/Events';
 
 const options = [
   { value: 'perspective', event: 'cameraperspectivetoggle', payload: null, label: 'Perspective' },

--- a/src/components/viewport/CameraToolbar.js
+++ b/src/components/viewport/CameraToolbar.js
@@ -9,7 +9,7 @@ const options = [
   { value: 'orthotop', event: 'cameraorthographictoggle', payload: 'top', label: 'Top View' },
   { value: 'orthobottom', event: 'cameraorthographictoggle', payload: 'bottom', label: 'Bottom View' },
   { value: 'orthoback', event: 'cameraorthographictoggle', payload: 'back', label: 'Back View' },
-  { value: 'orthofront', event: 'cameraorthographictoggle', payload: 'front', label: 'Front View' },
+  { value: 'orthofront', event: 'cameraorthographictoggle', payload: 'front', label: 'Front View' }
 ];
 
 function getOption (value) {

--- a/src/components/viewport/TransformToolbar.js
+++ b/src/components/viewport/TransformToolbar.js
@@ -1,6 +1,6 @@
-var React = require('react');
-var Events = require('../../lib/Events.js');
-var classNames = require('classnames');
+import React from 'react';
+import classNames from 'classnames';
+import Events from '../../lib/Events';
 
 var TransformButtons = [
   { value: 'translate', icon: 'fa-arrows-alt' },

--- a/src/components/viewport/ViewportHUD.js
+++ b/src/components/viewport/ViewportHUD.js
@@ -1,5 +1,5 @@
-var React = require('react');
-var Events = require('../../lib/Events.js');
+import React from 'react';
+import Events from '../../lib/Events';
 import { printEntity } from '../../lib/entity';
 
 export default class ViewportHUD extends React.Component {

--- a/src/components/widgets/BooleanWidget.js
+++ b/src/components/widgets/BooleanWidget.js
@@ -1,4 +1,4 @@
-var React = require('react');
+import React from 'react';
 import PropTypes from 'prop-types';
 
 export default class BooleanWidget extends React.Component {

--- a/src/components/widgets/ColorWidget.js
+++ b/src/components/widgets/ColorWidget.js
@@ -1,4 +1,4 @@
-var React = require('react');
+import React from 'react';
 import PropTypes from 'prop-types';
 
 export default class ColorWidget extends React.Component {

--- a/src/components/widgets/InputWidget.js
+++ b/src/components/widgets/InputWidget.js
@@ -1,4 +1,4 @@
-var React = require('react');
+import React from 'react';
 import PropTypes from 'prop-types';
 
 export default class InputWidget extends React.Component {

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -1,4 +1,4 @@
-var React = require('react');
+import React from 'react';
 import PropTypes from 'prop-types';
 import Select from 'react-select';
 

--- a/src/components/widgets/TextureWidget.js
+++ b/src/components/widgets/TextureWidget.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-var Events = require('../../lib/Events.js');
+import Events from '../../lib/Events';
 
 function getUrlFromId(assetId) {
   return (

--- a/src/components/widgets/TextureWidget.js
+++ b/src/components/widgets/TextureWidget.js
@@ -106,7 +106,7 @@ export default class TextureWidget extends React.Component {
     var context = canvas.getContext('2d');
 
     function paintPreviewWithImage(image) {
-      var filename = image.src.replace(/^.*[\\\/]/, '');
+      var filename = image.src.replace(/^.*[\\/]/, '');
       if (image !== undefined && image.width > 0) {
         canvas.title = filename;
         var scale = canvas.width / image.width;

--- a/src/components/widgets/index.js
+++ b/src/components/widgets/index.js
@@ -1,11 +1,9 @@
-module.exports = {
-  BooleanWidget: require('./BooleanWidget').default,
-  ColorWidget: require('./ColorWidget').default,
-  InputWidget: require('./InputWidget').default,
-  NumberWidget: require('./NumberWidget').default,
-  SelectWidget: require('./SelectWidget').default,
-  TextureWidget: require('./TextureWidget').default,
-  Vec4Widget: require('./Vec4Widget').default,
-  Vec3Widget: require('./Vec3Widget').default,
-  Vec2Widget: require('./Vec2Widget').default
-};
+export { default as BooleanWidget } from './BooleanWidget';
+export { default as ColorWidget } from './ColorWidget';
+export { default as InputWidget } from './InputWidget';
+export { default as NumberWidget } from './NumberWidget';
+export { default as SelectWidget } from './SelectWidget';
+export { default as TextureWidget } from './TextureWidget';
+export { default as Vec4Widget } from './Vec4Widget';
+export { default as Vec3Widget } from './Vec3Widget';
+export { default as Vec2Widget } from './Vec2Widget';

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,18 @@
-require('../vendor/ga');
+import '../vendor/ga';
 
-var Events = require('./lib/Events');
-var Viewport = require('./lib/viewport');
-var AssetsLoader = require('./lib/assetsLoader');
-var Shortcuts = require('./lib/shortcuts');
+import Events from './lib/Events';
+import { Viewport } from './lib/viewport';
+import { AssetsLoader } from './lib/assetsLoader';
+import { Shortcuts } from './lib/shortcuts';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Main from './components/Main';
 import { initCameras } from './lib/cameras';
-import { injectCSS, injectJS } from './lib/utils';
 import { createEntity } from './lib/entity';
 import { GLTFExporter } from '../vendor/GLTFExporter'; // eslint-disable-line no-unused-vars
 
-require('./style/index.styl');
+import './style/index.styl';
 
 function Inspector() {
   this.assetsLoader = new AssetsLoader();

--- a/src/index.js
+++ b/src/index.js
@@ -301,4 +301,4 @@ Inspector.prototype = {
   }
 };
 
-const inspector = (AFRAME.INSPECTOR = new Inspector());
+AFRAME.INSPECTOR = new Inspector();

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-/* global VERSION BUILD_TIMESTAMP COMMIT_HASH webFont */
 require('../vendor/ga');
 
 var Events = require('./lib/Events');

--- a/src/lib/EditorControls.js
+++ b/src/lib/EditorControls.js
@@ -135,7 +135,7 @@ THREE.EditorControls = function(_object, domElement) {
   };
 
   this.pan = function(delta) {
-     var distance;
+    var distance;
     if (this.isOrthographic) {
       distance = Math.abs(object.right);
     } else {
@@ -154,7 +154,7 @@ THREE.EditorControls = function(_object, domElement) {
   var ratio = 1;
   this.setAspectRatio = function (_ratio) {
     ratio = _ratio;
-  }
+  };
 
   this.zoom = function(delta) {
     var distance = object.position.distanceTo(center);
@@ -331,8 +331,9 @@ THREE.EditorControls = function(_object, domElement) {
       var closest = touches[0];
 
       for (var i in touches) {
-        if (closest.distanceTo(touch) > touches[i].distanceTo(touch))
+        if (closest.distanceTo(touch) > touches[i].distanceTo(touch)) {
           closest = touches[i];
+        }
       }
 
       return closest;

--- a/src/lib/Events.js
+++ b/src/lib/Events.js
@@ -1,22 +1,6 @@
-const EventEmitter = require('events').EventEmitter;
-const emitter = new EventEmitter();
-emitter.setMaxListeners(0);
+import EventEmitter from 'events';
 
-function Events() {}
+const Events = new EventEmitter();
+Events.setMaxListeners(0);
 
-Events.prototype.on = function() {
-  emitter.on.apply(emitter, arguments);
-  return this;
-};
-
-Events.prototype.emit = function() {
-  emitter.emit.apply(emitter, arguments);
-  return this;
-};
-
-Events.prototype.removeListener = function() {
-  emitter.removeListener.apply(emitter, arguments);
-  return this;
-};
-
-module.exports = new Events();
+export default Events;

--- a/src/lib/TransformControls.js
+++ b/src/lib/TransformControls.js
@@ -1,4 +1,4 @@
-/* eslint-disable curly */
+/* eslint-disable curly, dot-notation */
 /**
  * @author arodic / https://github.com/arodic
  */
@@ -1174,9 +1174,9 @@
             scope.object.quaternion.copy(tempQuaternion);
           } else if (scope.axis === 'XYZE') {
             var p = point
-                .clone()
-                .cross(tempVector)
-                .normalize();
+              .clone()
+              .cross(tempVector)
+              .normalize();
             quaternionE.setFromEuler(tempEuler.set(p.x, p.y, p.z)); // rotation axis
 
             tempQuaternion.setFromRotationMatrix(

--- a/src/lib/TransformControls.js
+++ b/src/lib/TransformControls.js
@@ -1,3 +1,4 @@
+/* eslint-disable curly */
 /**
  * @author arodic / https://github.com/arodic
  */
@@ -74,7 +75,7 @@
       this.add(this.pickers);
       this.add(this.planes);
 
-      //// PLANES
+      // PLANES
 
       var planeGeometry = new THREE.PlaneGeometry(50, 50, 2, 2);
       var planeMaterial = new THREE.MeshBasicMaterial({
@@ -100,11 +101,11 @@
         this.planes[i] = planes[i];
       }
 
-      //// HANDLES AND PICKERS
+      // HANDLES AND PICKERS
 
       var setupGizmos = function(gizmoMap, parent) {
         for (var name in gizmoMap) {
-          for (i = gizmoMap[name].length; i--; ) {
+          for (i = gizmoMap[name].length; i--;) {
             var object = gizmoMap[name][i][0];
             var position = gizmoMap[name][i][1];
             var rotation = gizmoMap[name][i][2];
@@ -406,7 +407,7 @@
       var CircleGeometry = function(radius, facing, arc) {
         var geometry = new THREE.BufferGeometry();
         var vertices = [];
-        arc = arc ? arc : 1;
+        arc = arc || 1;
 
         for (var i = 0; i <= 64 * arc; ++i) {
           if (facing === 'x')
@@ -833,7 +834,7 @@
 
       this.setCamera = function (_camera) {
         camera = _camera;
-      }
+      };
 
       this.activate = function() {
         domElement.addEventListener('mousedown', onPointerDown, false);
@@ -888,7 +889,7 @@
       };
 
       this.setMode = function(mode) {
-        _mode = mode ? mode : _mode;
+        _mode = mode || _mode;
 
         if (_mode === 'scale') scope.space = 'local';
 
@@ -1175,7 +1176,7 @@
             var p = point
                 .clone()
                 .cross(tempVector)
-                .normalize()
+                .normalize();
             quaternionE.setFromEuler(tempEuler.set(p.x, p.y, p.z)); // rotation axis
 
             tempQuaternion.setFromRotationMatrix(

--- a/src/lib/assetsLoader.js
+++ b/src/lib/assetsLoader.js
@@ -1,4 +1,3 @@
-/* global XMLHttpRequest JSON */
 import Events from './Events';
 
 const assetsBaseUrl = 'https://aframe.io/sample-assets/';

--- a/src/lib/assetsLoader.js
+++ b/src/lib/assetsLoader.js
@@ -17,7 +17,7 @@ AssetsLoader.prototype = {
    */
   load: function() {
     var xhr = new XMLHttpRequest();
-    var url = assetsBaseUrl + assetsRelativeUrl['images'];
+    var url = assetsBaseUrl + assetsRelativeUrl.images;
 
     // @todo Remove the sync call and use a callback
     xhr.open('GET', url);

--- a/src/lib/assetsLoader.js
+++ b/src/lib/assetsLoader.js
@@ -6,7 +6,7 @@ const assetsRelativeUrl = { images: 'dist/images.json' };
 /**
  * Asynchronously load and register components from the registry.
  */
-function AssetsLoader() {
+export function AssetsLoader() {
   this.images = [];
   this.hasLoaded = false;
 }
@@ -40,5 +40,3 @@ AssetsLoader.prototype = {
     this.hasLoaded = true;
   }
 };
-
-module.exports = AssetsLoader;

--- a/src/lib/assetsUtils.js
+++ b/src/lib/assetsUtils.js
@@ -1,4 +1,10 @@
-function insertNewAsset(type, id, src, anonymousCrossOrigin, onLoadedCallback) {
+export function insertNewAsset(
+  type,
+  id,
+  src,
+  anonymousCrossOrigin,
+  onLoadedCallback
+) {
   var element = null;
   switch (type) {
     case 'img':
@@ -22,7 +28,3 @@ function insertNewAsset(type, id, src, anonymousCrossOrigin, onLoadedCallback) {
     document.getElementsByTagName('a-assets')[0].appendChild(element);
   }
 }
-
-module.exports = {
-  insertNewAsset: insertNewAsset
-};

--- a/src/lib/cameras.js
+++ b/src/lib/cameras.js
@@ -78,7 +78,7 @@ export function initCameras (inspector) {
   });
 
   return inspector.cameras;
-};
+}
 
 function saveOrthoCamera (camera, dir) {
   if (camera.type !== 'OrthographicCamera') { return; }

--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -1,7 +1,6 @@
 import React from 'react';
-var Events = require('../lib/Events.js');
-
-import { equal } from '../lib/utils.js';
+import Events from './Events';
+import { equal } from './utils';
 
 /**
  * Update a component.

--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -129,7 +129,7 @@ export function cloneEntity(entity) {
   entity.flushToDOM();
 
   const clone = entity.cloneNode(true);
-  clone.addEventListener('loaded', function(e) {
+  clone.addEventListener('loaded', function() {
     AFRAME.INSPECTOR.selectEntity(clone);
     Events.emit('entityclone');
   });

--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-danger */
 import React from 'react';
 import Events from './Events';
 import { equal } from './utils';

--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -519,10 +519,6 @@ export function getComponentClipboardRepresentation(entity, componentName) {
   return `${componentName}="${attributes}"`;
 }
 
-function isEmpty(string) {
-  return string === null || string === '';
-}
-
 /**
  * Entity representation.
  */

--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -1,6 +1,6 @@
-const Events = require('./Events');
+import Events from './Events';
 
-const updates = {};
+export const updates = {};
 
 /**
  * Store change to export.
@@ -28,7 +28,3 @@ Events.on('entityupdate', payload => {
     }
   }
 });
-
-module.exports = {
-  updates: updates
-};

--- a/src/lib/raycaster.js
+++ b/src/lib/raycaster.js
@@ -1,7 +1,7 @@
-const Events = require('./Events');
-const debounce = require('lodash.debounce');
+import Events from './Events';
+import debounce from 'lodash.debounce';
 
-function initRaycaster(inspector) {
+export function initRaycaster(inspector) {
   // Use cursor="rayOrigin: mouse".
   const mouseCursor = document.createElement('a-entity');
   mouseCursor.setAttribute('id', 'aframeInspectorMouseCursor');
@@ -148,7 +148,6 @@ function initRaycaster(inspector) {
     }
   };
 }
-module.exports.initRaycaster = initRaycaster;
 
 function getMousePosition(dom, x, y) {
   const rect = dom.getBoundingClientRect();

--- a/src/lib/raycaster.js
+++ b/src/lib/raycaster.js
@@ -101,26 +101,6 @@ export function initRaycaster(inspector) {
     onUpPosition.fromArray(array);
   }
 
-  function onTouchStart(event) {
-    const touch = event.changedTouches[0];
-    const array = getMousePosition(
-      inspector.container,
-      touch.clientX,
-      touch.clientY
-    );
-    onDownPosition.fromArray(array);
-  }
-
-  function onTouchEnd(event) {
-    const touch = event.changedTouches[0];
-    const array = getMousePosition(
-      inspector.container,
-      touch.clientX,
-      touch.clientY
-    );
-    onUpPosition.fromArray(array);
-  }
-
   /**
    * Focus on double click.
    */

--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -1,10 +1,12 @@
-var Events = require('./Events');
+import Events from './Events';
 import {
   removeSelectedEntity,
   cloneSelectedEntity,
   cloneEntity
-} from '../lib/entity';
-import { os } from '../lib/utils.js';
+} from './entity';
+import { getOS } from './utils';
+
+const os = getOS();
 
 function shouldCaptureKeyEvent(event) {
   if (event.metaKey) {
@@ -16,7 +18,7 @@ function shouldCaptureKeyEvent(event) {
   );
 }
 
-var Shortcuts = {
+export const Shortcuts = {
   enabled: false,
   shortcuts: {
     default: {},
@@ -221,5 +223,3 @@ var Shortcuts = {
     this.onKeyUp = this.onKeyUp.bind(this);
   }
 };
-
-module.exports = Shortcuts;

--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -1,4 +1,3 @@
-/* globals AFRAME */
 var Events = require('./Events');
 import {
   removeSelectedEntity,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,8 +1,8 @@
-function getNumber(value) {
+export function getNumber(value) {
   return parseFloat(value.toFixed(3));
 }
 
-function getMajorVersion(version) {
+export function getMajorVersion(version) {
   var major = version.split('.');
   var clean = false;
   for (var i = 0; i < major.length; i++) {
@@ -15,7 +15,7 @@ function getMajorVersion(version) {
   return major.join('.');
 }
 
-function equal(var1, var2) {
+export function equal(var1, var2) {
   var keys1;
   var keys2;
   var type1 = typeof var1;
@@ -39,7 +39,7 @@ function equal(var1, var2) {
   return true;
 }
 
-function getOS() {
+export function getOS() {
   var userAgent = window.navigator.userAgent;
   var platform = window.navigator.platform;
   var macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
@@ -62,7 +62,7 @@ function getOS() {
   return os;
 }
 
-function injectCSS(url) {
+export function injectCSS(url) {
   var link = document.createElement('link');
   link.href = url;
   link.type = 'text/css';
@@ -72,7 +72,7 @@ function injectCSS(url) {
   document.head.appendChild(link);
 }
 
-function injectJS(url, onLoad, onError) {
+export function injectJS(url, onLoad, onError) {
   var link = document.createElement('script');
   link.src = url;
   link.charset = 'utf-8';
@@ -89,11 +89,11 @@ function injectJS(url, onLoad, onError) {
   document.head.appendChild(link);
 }
 
-function saveString(text, filename, mimeType) {
+export function saveString(text, filename, mimeType) {
   saveBlob(new Blob([text], { type: mimeType }), filename);
 }
 
-function saveBlob(blob, filename) {
+export function saveBlob(blob, filename) {
   var link = document.createElement('a');
   link.style.display = 'none';
   document.body.appendChild(link);
@@ -102,15 +102,3 @@ function saveBlob(blob, filename) {
   link.click();
   // URL.revokeObjectURL(url); breaks Firefox...
 }
-
-module.exports = {
-  equal: equal,
-  getNumber: getNumber,
-  getMajorVersion: getMajorVersion,
-  getOS: getOS,
-  os: getOS(),
-  injectCSS: injectCSS,
-  injectJS: injectJS,
-  saveString: saveString,
-  saveBlob: saveBlob
-};

--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -1,6 +1,4 @@
 /* global THREE CustomEvent */
-import debounce from 'lodash.debounce';
-
 /* eslint-disable no-unused-vars */
 import TransformControls from './TransformControls.js';
 import EditorControls from './EditorControls.js';
@@ -8,7 +6,6 @@ import EditorControls from './EditorControls.js';
 
 import { initRaycaster } from './raycaster';
 
-import { getNumber } from './utils';
 const Events = require('./Events');
 
 /**

--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -96,7 +96,7 @@ export function Viewport(inspector) {
   sceneHelpers.add(transformControls);
 
   Events.on('entityupdate', detail => {
-    if (inspector.selectedEntity.object3DMap['mesh']) {
+    if (inspector.selectedEntity.object3DMap.mesh) {
       selectionBox.setFromObject(inspector.selected);
     }
   });

--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -3,13 +3,12 @@ import TransformControls from './TransformControls.js';
 import EditorControls from './EditorControls.js';
 
 import { initRaycaster } from './raycaster';
-
-const Events = require('./Events');
+import Events from './Events';
 
 /**
  * Transform controls stuff mostly.
  */
-function Viewport(inspector) {
+export function Viewport(inspector) {
   // Initialize raycaster and picking in differentpmodule.
   const mouseCursor = initRaycaster(inspector);
   const sceneEl = inspector.sceneEl;
@@ -226,5 +225,3 @@ function Viewport(inspector) {
     ga('send', 'event', 'Viewport', 'toggleEditor', active);
   });
 }
-
-module.exports = Viewport;

--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -1,8 +1,6 @@
-/* global THREE CustomEvent */
 /* eslint-disable no-unused-vars */
 import TransformControls from './TransformControls.js';
 import EditorControls from './EditorControls.js';
-/* eslint-disable no-unused-vars */
 
 import { initRaycaster } from './raycaster';
 


### PR DESCRIPTION
- Remove dead code, unused imports, unused variables.
- Use import/export everywhere, latest wepback/babel don't allow to use module.exports if you used one import statement.
- Specify a prettier config with option singleQuote to match the current code. I didn't reformatted the files with prettier in this PR.
- Disable the eslint space-before-function-paren rule that conflicts with how prettier format the files.
- Fix eslint errors.