### PR TITLE
Fix style issues with bootstrap or tailwind in the site

### DIFF
--- a/src/style/components.styl
+++ b/src/style/components.styl
@@ -49,6 +49,7 @@ div.vec4
 .collapsible .static
   background $bglight
   border-bottom 2px solid $bg
+  box-sizing content-box
   cursor pointer
   height 16px
   padding 8px 10px 12px 10px
@@ -133,8 +134,10 @@ div.vec4
     background $bgdark
     color #1faaf2
     min-height 26px
+    padding-bottom 1px
     padding-left 5px
     padding-right 5px
+    padding-top 1px
     &:last-child
       padding-right 0
 

--- a/src/style/index.styl
+++ b/src/style/index.styl
@@ -72,11 +72,14 @@ body.aframe-inspector-opened
     outline none /* osx */
 
   .gltfIcon img
+    box-sizing content-box
+    display inline
     height 20px
     left 5px
     padding 0 5px
     position relative
     top 4px
+    vertical-align baseline
     width 20px
 
   #scenegraph,
@@ -91,9 +94,11 @@ body.aframe-inspector-opened
 
   .toggle-edit
     background-color $red
+    box-sizing content-box
     color #FAFAFA
     font-size 13px
     left 3px
+    line-height normal
     margin 0
     padding 6px 10px
     position fixed

--- a/src/style/scenegraph.styl
+++ b/src/style/scenegraph.styl
@@ -126,6 +126,7 @@
     flex 1 1 auto
     font-size 13px
     height calc(100% - 98px)
+    line-height normal
     outline none
     overflow-y auto
     padding 0


### PR DESCRIPTION
Specify default css properties on some elements to fix style issues when using the inspector in a site that has tailwind base.css or bootstrap reset styles.

Before:
![Capture d’écran du 2022-10-04 20-35-46](https://user-images.githubusercontent.com/112249/194326667-8d71293d-954b-4035-86aa-0bc4f7b67554.jpg)

After:
![Capture d’écran du 2022-10-06 15-34-20](https://user-images.githubusercontent.com/112249/194327136-8657dbbb-f35a-48a6-8fcb-ccd5b59ead81.jpg)

Remaining fixes to do:
- [ ] local checkbox and other checkboxes for boolean properties is always black
- [ ] the id/class on the top bar is not aligned with `<a-entity`
- [ ] in the outliner the line height change slightly if I remove or add class
