### PR TITLE
Be able to easily create a build without Google Analytics

### DIFF
--- a/src/components/Collapsible.js
+++ b/src/components/Collapsible.js
@@ -23,7 +23,9 @@ export default class Collapsible extends React.Component {
 
   toggleVisibility = () => {
     this.setState({ collapsed: !this.state.collapsed });
-    ga('send', 'event', 'Components', 'collapse');
+    if (typeof ga !== 'undefined') {
+      ga('send', 'event', 'Components', 'collapse');
+    }
   };
 
   render() {

--- a/src/components/components/AddComponent.js
+++ b/src/components/components/AddComponent.js
@@ -32,7 +32,9 @@ export default class AddComponent extends React.Component {
 
     entity.setAttribute(componentName, '');
     Events.emit('componentadd', { entity: entity, component: componentName });
-    ga('send', 'event', 'Components', 'addComponent', componentName);
+    if (typeof ga !== 'undefined') {
+      ga('send', 'event', 'Components', 'addComponent', componentName);
+    }
   };
 
   /**

--- a/src/components/components/Component.js
+++ b/src/components/components/Component.js
@@ -36,13 +36,15 @@ export default class Component extends React.Component {
           var componentName = trigger
             .getAttribute('data-component')
             .toLowerCase();
-          ga(
-            'send',
-            'event',
-            'Components',
-            'copyComponentToClipboard',
-            componentName
-          );
+          if (typeof ga !== 'undefined') {
+            ga(
+              'send',
+              'event',
+              'Components',
+              'copyComponentToClipboard',
+              componentName
+            );
+          }
           return getComponentClipboardRepresentation(
             this.state.entity,
             componentName
@@ -85,7 +87,9 @@ export default class Component extends React.Component {
         entity: this.props.entity,
         component: componentName
       });
-      ga('send', 'event', 'Components', 'removeComponent', componentName);
+      if (typeof ga !== 'undefined') {
+        ga('send', 'event', 'Components', 'removeComponent', componentName);
+      }
     }
   };
 

--- a/src/components/components/Mixins.js
+++ b/src/components/components/Mixins.js
@@ -65,7 +65,9 @@ export default class Mixin extends React.Component {
       property: '',
       value: mixinStr
     });
-    ga('send', 'event', 'Components', 'addMixin');
+    if (typeof ga !== 'undefined') {
+      ga('send', 'event', 'Components', 'addMixin');
+    }
   };
 
   render() {

--- a/src/components/components/Sidebar.js
+++ b/src/components/components/Sidebar.js
@@ -26,7 +26,9 @@ export default class Sidebar extends React.Component {
 
   handleToggle = () => {
     this.setState({ open: !this.state.open });
-    ga('send', 'event', 'Components', 'toggleSidebar');
+    if (typeof ga !== 'undefined') {
+      ga('send', 'event', 'Components', 'toggleSidebar');
+    }
   };
 
   render() {

--- a/src/components/scenegraph/Toolbar.js
+++ b/src/components/scenegraph/Toolbar.js
@@ -46,7 +46,9 @@ export default class Toolbar extends React.Component {
   }
 
   exportSceneToGLTF() {
-    ga('send', 'event', 'SceneGraph', 'exportGLTF');
+    if (typeof ga !== 'undefined') {
+      ga('send', 'event', 'SceneGraph', 'exportGLTF');
+    }
     const sceneName = getSceneName(AFRAME.scenes[0]);
     const scene = AFRAME.scenes[0].object3D;
     filterHelpers(scene, false);

--- a/src/components/viewport/TransformToolbar.js
+++ b/src/components/viewport/TransformToolbar.js
@@ -34,7 +34,9 @@ export default class TransformToolbar extends React.Component {
   changeTransformMode = mode => {
     this.setState({ selectedTransform: mode });
     Events.emit('transformmodechange', mode);
-    ga('send', 'event', 'Toolbar', 'selectHelper', mode);
+    if (typeof ga !== 'undefined') {
+      ga('send', 'event', 'Toolbar', 'selectHelper', mode);
+    }
   };
 
   onLocalChange = e => {

--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -228,7 +228,9 @@ function Viewport(inspector) {
           element.style.display = 'block';
         });
     }
-    ga('send', 'event', 'Viewport', 'toggleEditor', active);
+    if (typeof ga !== 'undefined') {
+      ga('send', 'event', 'Viewport', 'toggleEditor', active);
+    }
   });
 }
 


### PR DESCRIPTION
For GDPR compliance, you may want to create a build without Google Analytics. I added condition around the `ga()` calls to be able to easily create a build without Google Analytics but just commenting the `require('../vendor/ga');` in `index.js`.