### PR TITLE
Fix 0 Toggle panels shortcut not properly working

### DIFF
--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -49,17 +49,15 @@ export default class Main extends React.Component {
         }
       } else if (event.which === 'attributes') {
         this.setState(prevState => ({
-          visible: {
-            ...prevState.visible,
+          visible: Object.assign({}, prevState.visible, {
             attributes: !prevState.visible.attributes
-          }
+          })
         }));
       } else if (event.which === 'scenegraph') {
         this.setState(prevState => ({
-          visible: {
-            ...prevState.visible,
+          visible: Object.assign({}, prevState.visible, {
             scenegraph: !prevState.visible.scenegraph
-          }
+          })
         }));
       }
     });

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -50,12 +50,14 @@ export default class Main extends React.Component {
       } else if (event.which === 'attributes') {
         this.setState(prevState => ({
           visible: {
+            ...prevState.visible,
             attributes: !prevState.visible.attributes
           }
         }));
       } else if (event.which === 'scenegraph') {
         this.setState(prevState => ({
           visible: {
+            ...prevState.visible,
             scenegraph: !prevState.visible.scenegraph
           }
         }));
@@ -118,7 +120,7 @@ export default class Main extends React.Component {
       <div className="toggle-sidebar right">
         <a
           onClick={() => {
-            this.setState({ visible: { attributes: true } });
+            Events.emit('togglesidebar', { which: 'attributes' });
           }}
           className="fa fa-plus"
           title="Show components"
@@ -135,7 +137,7 @@ export default class Main extends React.Component {
       <div className="toggle-sidebar left">
         <a
           onClick={() => {
-            this.setState({ visible: { scenegraph: true } });
+            Events.emit('togglesidebar', { which: 'scenegraph' });
           }}
           className="fa fa-plus"
           title="Show scenegraph"

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -60,8 +60,6 @@ export default class Main extends React.Component {
           }
         }));
       }
-
-      this.forceUpdate();
     });
   }
 
@@ -117,7 +115,6 @@ export default class Main extends React.Component {
         <a
           onClick={() => {
             this.setState({ visible: { attributes: true } });
-            this.forceUpdate();
           }}
           className="fa fa-plus"
           title="Show components"
@@ -135,7 +132,6 @@ export default class Main extends React.Component {
         <a
           onClick={() => {
             this.setState({ visible: { scenegraph: true } });
-            this.forceUpdate();
           }}
           className="fa fa-plus"
           title="Show scenegraph"

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -107,7 +107,11 @@ export default class Main extends React.Component {
   };
 
   renderComponentsToggle() {
-    if (!this.state.entity || this.state.visible.attributes) {
+    if (
+      !this.state.inspectorEnabled ||
+      !this.state.entity ||
+      this.state.visible.attributes
+    ) {
       return null;
     }
     return (
@@ -124,7 +128,7 @@ export default class Main extends React.Component {
   }
 
   renderSceneGraphToggle() {
-    if (this.state.visible.scenegraph) {
+    if (!this.state.inspectorEnabled || this.state.visible.scenegraph) {
       return null;
     }
     return (

--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -173,8 +173,8 @@ var Shortcuts = {
       this.disable();
     }
 
-    window.addEventListener('keydown', this.onKeyDown.bind(this), false);
-    window.addEventListener('keyup', this.onKeyUp.bind(this), false);
+    window.addEventListener('keydown', this.onKeyDown, false);
+    window.addEventListener('keyup', this.onKeyUp, false);
     this.enabled = true;
   },
   disable: function() {
@@ -188,7 +188,7 @@ var Shortcuts = {
       this.shortcuts.modules[moduleName][keyCode]
     ) {
       console.warn(
-        'Keycode <%s> already registered as shorcut within the same module',
+        'Keycode <%s> already registered as shortcut within the same module',
         keyCode
       );
     }

--- a/src/style/index.styl
+++ b/src/style/index.styl
@@ -258,7 +258,9 @@ body.aframe-inspector-opened
       color #fff
 
   .toggle-sidebar.left
-      left 0
+    top 0
+    left 0
 
   .toggle-sidebar.right
-      right 0
+    top 0
+    right 0

--- a/src/style/index.styl
+++ b/src/style/index.styl
@@ -247,12 +247,6 @@ body.aframe-inspector-opened
     position absolute
     z-index 9998
 
-    .left
-      left 0
-
-    .right
-      right 0
-
     a
       background-color #262626
       color #bcbcbc
@@ -262,3 +256,9 @@ body.aframe-inspector-opened
     a.hover
       background-color #1faaf2
       color #fff
+
+  .toggle-sidebar.left
+      left 0
+
+  .toggle-sidebar.right
+      right 0


### PR DESCRIPTION
When disabling the editor and enabling it again via the `Back to scene` followed by `Inspect scene` button, the `0 Toggle panels` shortcut wasn't properly working one time over two. This was because the listeners was added a second time, a third time, forth time... so removing the listeners in `disable()` wasn't working properly.

`this.onKeyDown`, `this.onKeyUp` are already bound in init.
The function given to addEventListener in `enable()` and removeEventListener in `disable()` needs to be the same.