### PR TITLE
Fix inspector toggle on US international keyboards

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,9 @@ Inspector.prototype = {
   initEvents: function() {
     window.addEventListener('keydown', evt => {
       // Alt + Ctrl + i: Shorcut to toggle the inspector
-      var shortcutPressed = evt.keyCode === 73 && evt.ctrlKey && evt.altKey;
+      var shortcutPressed =
+        evt.keyCode === 73 &&
+        ((evt.ctrlKey && evt.altKey) || evt.getModifierState('AltGraph'));
       if (shortcutPressed) {
         this.toggle();
       }


### PR DESCRIPTION
This replaces #598 with the correct prettier formatting. It was part of #647