### PR TITLE
Cancel tailwindcss default style on select input when adding a component

### DIFF
--- a/src/style/components.styl
+++ b/src/style/components.styl
@@ -195,11 +195,12 @@ a.help-linkhover
       span
         color $primary
 
-
-
   #addComponentHeader
     font-size 15px
     margin 5px 0 10px 0
+
+  input[type=text]:focus
+    box-shadow none
 
 .Select-menu-outer .is-focused span
   color #fff


### PR DESCRIPTION
I missed a case when I did #667

![Capture d’écran du 2022-12-30 14-03-37](https://user-images.githubusercontent.com/112249/210073803-c7c0e1d3-7937-4f6d-b812-50ade51e0100.png)
The change remove the blue border in the screenshot.