### PR TITLE
Really use the newly active camera when exiting edit mode

### DIFF
--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -13,11 +13,10 @@ export function Viewport(inspector) {
   const mouseCursor = initRaycaster(inspector);
   const sceneEl = inspector.sceneEl;
 
-  let originalCamera = inspector.cameras.original;
   sceneEl.addEventListener('camera-set-active', (event) => {
     // If we're in edit mode, save the newly active camera and activate when exiting.
     if (inspector.opened) {
-      originalCamera = event.detail.cameraEl;
+      inspector.cameras.original = event.detail.cameraEl;
     }
   });
 


### PR DESCRIPTION
The code didn't make sense, it didn't do anything. It didn't do what the comment says, now it does.
You can test it:
- go in edit mode
- add a new entity and add a camera component, this camera will be active, the previous one has active unchecked.
- click on "Back to scene" button

The new active camera is correctly used.