### PR TITLE
Remove double spaces when copying component representation

### DIFF
--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -514,9 +514,7 @@ export function getComponentClipboardRepresentation(entity, componentName) {
   }
 
   const diff = getModifiedProperties(entity, componentName);
-  const attributes = AFRAME.utils.styleParser
-    .stringify(diff)
-    .replace(/;|:/g, '$& ');
+  const attributes = AFRAME.utils.styleParser.stringify(diff);
   return `${componentName}="${attributes}"`;
 }
 


### PR DESCRIPTION
Copy entity to clipboard calls `getEntityClipboardRepresentation` and at the end uses 
https://github.com/aframevr/aframe-inspector/blob/e8798c73b6abd51566107e21a007f6fe90fbb5ad/src/lib/entity.js#L245
This is correct:
```
<a-entity position="0 0.1 0" material-values__glass="materialName: glass; metalness: 0.882; roughness: 0.055; opacity: 0.9" gltf-model="car.glb"></a-entity>
```

Copy component values to clipboard calls `getComponentClipboardRepresentation` and at the end uses https://github.com/aframevr/aframe-inspector/blob/e8798c73b6abd51566107e21a007f6fe90fbb5ad/src/lib/entity.js#L517-L519
producing double spaces.
```
material-values__glass="materialName:  glass;  metalness:  0.882;  roughness:  0.055;  opacity: 0.9"
```

For consistency, remove double spaces.