### PR TITLE
Use Object.is to handle NaN comparison in NumberWidget to avoid infinite React update (fix #677)

### DIFF
--- a/src/components/widgets/NumberWidget.js
+++ b/src/components/widgets/NumberWidget.js
@@ -113,6 +113,9 @@ export default class NumberWidget extends React.Component {
   componentDidUpdate(prevProps) {
     // This will be triggered typically when the element is changed directly with
     // element.setAttribute.
+
+    // We use Object.is instead of === for comparison here so that comparing two NaN doesn't trigger an infinite update.
+    // Object.is(NaN, NaN) is true, NaN === NaN is false
     if (!Object.is(this.props.value, prevProps.value)) {
       this.setState({
         value: this.props.value,

--- a/src/components/widgets/NumberWidget.js
+++ b/src/components/widgets/NumberWidget.js
@@ -113,7 +113,7 @@ export default class NumberWidget extends React.Component {
   componentDidUpdate(prevProps) {
     // This will be triggered typically when the element is changed directly with
     // element.setAttribute.
-    if (this.props.value !== prevProps.value) {
+    if (!Object.is(this.props.value, prevProps.value)) {
       this.setState({
         value: this.props.value,
         displayValue: this.props.value.toFixed(this.props.precision)

--- a/src/components/widgets/Vec2Widget.js
+++ b/src/components/widgets/Vec2Widget.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import NumberWidget from './NumberWidget';
+import { areVectorsEqual } from '../../lib/utils';
 
 export default class Vec2Widget extends React.Component {
   static propTypes = {
@@ -29,7 +30,7 @@ export default class Vec2Widget extends React.Component {
 
   componentDidUpdate() {
     const props = this.props;
-    if (props.value.x !== this.state.x || props.value.y !== this.state.y) {
+    if (!areVectorsEqual(props.value, this.state)) {
       this.setState({
         x: props.value.x,
         y: props.value.y

--- a/src/components/widgets/Vec3Widget.js
+++ b/src/components/widgets/Vec3Widget.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import NumberWidget from './NumberWidget';
+import { areVectorsEqual } from '../../lib/utils';
 
 export default class Vec3Widget extends React.Component {
   static propTypes = {
@@ -30,11 +31,7 @@ export default class Vec3Widget extends React.Component {
 
   componentDidUpdate() {
     const props = this.props;
-    if (
-      props.value.x !== this.state.x ||
-      props.value.y !== this.state.y ||
-      props.value.z !== this.state.z
-    ) {
+    if (!areVectorsEqual(props.value, this.state)) {
       this.setState({
         x: props.value.x,
         y: props.value.y,

--- a/src/components/widgets/Vec4Widget.js
+++ b/src/components/widgets/Vec4Widget.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import NumberWidget from './NumberWidget';
+import { areVectorsEqual } from '../../lib/utils';
 
 export default class Vec4Widget extends React.Component {
   static propTypes = {
@@ -31,12 +32,7 @@ export default class Vec4Widget extends React.Component {
 
   componentDidUpdate() {
     const props = this.props;
-    if (
-      props.value.x !== this.state.x ||
-      props.value.y !== this.state.y ||
-      props.value.z !== this.state.z ||
-      props.value.w !== this.state.w
-    ) {
+    if (!areVectorsEqual(props.value, this.state)) {
       this.setState({
         x: props.value.x,
         y: props.value.y,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -102,3 +102,15 @@ export function saveBlob(blob, filename) {
   link.click();
   // URL.revokeObjectURL(url); breaks Firefox...
 }
+
+// Compares 2 vector objects up to size 4
+// Expect v1 and v2 to take format {x: number, y: number, z: number, w:number}
+// Smaller vectors (ie. vec2) should work as well since their z & w vals will be the same (undefined)
+export function areVectorsEqual(v1, v2) {
+  return (
+    Object.is(v1.x, v2.x) &&
+    Object.is(v1.y, v2.y) &&
+    Object.is(v1.z, v2.z) &&
+    Object.is(v1.w, v2.w)
+  );
+}


### PR DESCRIPTION
Problem:
Selecting an object in the scene with ammo physics applied crashes the inspector. 
Inspector also crashes if you happen to pass in something like "fog: false" for `aframe-environment-component` because it expects a number.

Steps to repro:
Open the example/index.html file in this repo. Click on the environment object in the scene, which happens to have the offending "fog: false" param. Inspector will crash.

Cause:
This happens when a component property value comes in as NaN. For example, somehow the `ammo-body` component's schema default value is `NaN`, and when this is passed through into `NumberWidget.js`, results in an infinite update because it thinks NaN !== NaN. The "fog: false" example also sends `NaN` as the value for `fog`, resulting in the same error.

Fix:
I swapped in `isObject` for a more robust check (will give true when comparing 2 NaNs) so that this infinite state update doesn't happen for similar scenarios.
