### PR TITLE
Properly unregister listeners on canvas when closing inspector

### DIFF
--- a/src/lib/raycaster.js
+++ b/src/lib/raycaster.js
@@ -127,9 +127,15 @@ export function initRaycaster(inspector) {
     el: mouseCursor,
     enable: () => {
       mouseCursor.setAttribute('raycaster', 'enabled', true);
+      inspector.container.addEventListener('mousedown', onMouseDown);
+      inspector.container.addEventListener('mouseup', onMouseUp);
+      inspector.container.addEventListener('dblclick', onDoubleClick);
     },
     disable: () => {
       mouseCursor.setAttribute('raycaster', 'enabled', false);
+      inspector.container.removeEventListener('mousedown', onMouseDown);
+      inspector.container.removeEventListener('mouseup', onMouseUp);
+      inspector.container.removeEventListener('dblclick', onDoubleClick);
     }
   };
 }


### PR DESCRIPTION
Properly unregister listeners on canvas (`inspector.container`) when closing inspector and register them back when opening again.
I verified, `enable` function here is called only when reopening, not at inspector initialization. So we don't end up registering the listeners twice. Those are registered on inspector initialization here 
https://github.com/aframevr/aframe-inspector/blob/aecc85bcd2dde219fc272240bf8bfcd3ebf87b03/src/lib/raycaster.js#L46-L48

The issue was the `event.preventDefault();` in `onMouseDown` here
https://github.com/aframevr/aframe-inspector/blob/aecc85bcd2dde219fc272240bf8bfcd3ebf87b03/src/lib/raycaster.js#L87
This listener was still active when the inspector was closed prevented the focus logic on canvas to work properly. For example closing the inspector, clicking on some other buttons on a custom UI and back to canvas, `document.activeElement` didn't come back to `document.body` preventing usage of wasd controls. The issue was found in two different applications, see https://github.com/3DStreet/3dstreet-editor/issues/130 for context.