### PR TITLE
Remove Box3.prototype.expandByObject patch

### DIFF
--- a/src/components/widgets/NumberWidget.js
+++ b/src/components/widgets/NumberWidget.js
@@ -92,6 +92,11 @@ export default class NumberWidget extends React.Component {
         value = parseFloat(value);
       }
 
+      // If we inadvertently typed a character in the field, set value to the previous value from props
+      if (isNaN(value)) {
+        value = this.props.value;
+      }
+
       if (value < this.props.min) {
         value = this.props.min;
       }

--- a/src/lib/EditorControls.js
+++ b/src/lib/EditorControls.js
@@ -1,57 +1,5 @@
 import debounce from 'lodash.debounce';
 
-THREE.Box3.prototype.expandByObject = (function () {
-  // Computes the world-axis-aligned bounding box of an object (including its children),
-  // accounting for both the object's, and children's, world transforms
-
-  var scope, i, l;
-
-  var v1 = new THREE.Vector3();
-
-  function traverse(node) {
-    var geometry = node.geometry;
-
-    if (geometry !== undefined) {
-      if (geometry.isGeometry) {
-        var vertices = geometry.vertices;
-
-        for (i = 0, l = vertices.length; i < l; i++) {
-          v1.copy(vertices[i]);
-          v1.applyMatrix4(node.matrixWorld);
-
-          if (isNaN(v1.x) || isNaN(v1.y) || isNaN(v1.z)) {
-            continue;
-          }
-          scope.expandByPoint(v1);
-        }
-      } else if (geometry.isBufferGeometry) {
-        var attribute = geometry.attributes.position;
-
-        if (attribute !== undefined) {
-          for (i = 0, l = attribute.count; i < l; i++) {
-            v1.fromBufferAttribute(attribute, i).applyMatrix4(node.matrixWorld);
-
-            if (isNaN(v1.x) || isNaN(v1.y) || isNaN(v1.z)) {
-              continue;
-            }
-            scope.expandByPoint(v1);
-          }
-        }
-      }
-    }
-  }
-
-  return function expandByObject(object) {
-    scope = this;
-
-    object.updateMatrixWorld(true);
-
-    object.traverse(traverse);
-
-    return this;
-  };
-})();
-
 /**
  * @author qiao / https://github.com/qiao
  * @author mrdoob / http://mrdoob.com


### PR DESCRIPTION
Remove `Box3.prototype.expandByObject` patch, this function is an old version of what now exists in latest threejs:
https://github.com/mrdoob/three.js/blob/25859b6bdf64a13301dffdad6369b0c675584aa4/src/math/Box3.js#L155-L220

I mentioned it in my comment https://github.com/aframevr/aframe-inspector/issues/649#issuecomment-1364654680
It's been months since I commented that code in my project to not patch Box3 with an old version of expandByObject. I didn't see any issue.

I verified for example with the blue cube with a sphere as a child
```
<a-entity id="blueBox" mixin="blueBox" position="0 8 0">
  <a-entity id="yellowSphere" geometry="primitive: sphere" material="color:#ff0; metalness:0.0; roughness:1.0" position="-2 2 -2"></a-entity>
</a-entity>
```
This works properly:
![Capture d’écran du 2023-04-17 15-47-53](https://user-images.githubusercontent.com/112249/232504933-ff38a486-aceb-4541-8d20-f710387fcb57.png)
