### PR TITLE
Fix duplicate entity feature not using the modified value for position/rotation/scale

### DIFF
--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -74,6 +74,11 @@ export function Viewport(inspector) {
       component = 'scale';
       value = `${object.scale.x} ${object.scale.y} ${object.scale.z}`;
     }
+
+    // We need to call setAttribute for component attrValue to be up to date,
+    // so that entity.flushToDOM() works correctly when duplicating an entity.
+    transformControls.object.el.setAttribute(component, value);
+
     Events.emit('entityupdate', {
       component: component,
       entity: transformControls.object.el,


### PR DESCRIPTION
Properly call `setAttribute` for position, rotation, scale when modifying with the TransformControls, so that `entity.flushToDOM()` works correctly when duplicating an entity.
This fixes #688.
See my comment https://github.com/aframevr/aframe-inspector/issues/688#issuecomment-1646632546 for a more detailed explanation of the issue and the proposed fix.