### PR TITLE
Replace fontawesome cdn by react-fontawesome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,16 @@
 {
   "name": "aframe-inspector",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aframe-inspector",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
+        "@fortawesome/free-solid-svg-icons": "^6.5.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
         "classnames": "^2.3.2",
         "clipboard": "^2.0.11",
         "lodash.debounce": "^4.0.8",
@@ -2027,6 +2029,52 @@
       "integrity": "sha512-HeG/wHoa2laUHlDX3xkzqlUqliAfa+zqV04LaKIwNCmCNaW2p0fQi4/Kd0LB4GdFoJ2UllLFq5gWnXAd67lg7w==",
       "dependencies": {
         "@floating-ui/core": "^1.0.4"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+      "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
+      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-S1PPfU3mIJa59biTtXJz1oI0+KAXW6bkAb31XKhxdxtuXDiUIFsih4JR1v5BbxY7hVHsD1RKq+jRkVRaf773NQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -15436,6 +15484,36 @@
       "integrity": "sha512-HeG/wHoa2laUHlDX3xkzqlUqliAfa+zqV04LaKIwNCmCNaW2p0fQi4/Kd0LB4GdFoJ2UllLFq5gWnXAd67lg7w==",
       "requires": {
         "@floating-ui/core": "^1.0.4"
+      }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+      "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
+      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
+      "peer": true,
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-S1PPfU3mIJa59biTtXJz1oI0+KAXW6bkAb31XKhxdxtuXDiUIFsih4JR1v5BbxY7hVHsD1RKq+jRkVRaf773NQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "requires": {
+        "prop-types": "^15.8.1"
       }
     },
     "@humanwhocodes/config-array": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.5.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "classnames": "^2.3.2",
-        "clipboard": "^2.0.11",
+        "clipboard-copy": "^4.0.1",
         "lodash.debounce": "^4.0.8",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
@@ -4447,15 +4447,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/clipboard": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
-      "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
-      "dependencies": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
+    "node_modules/clipboard-copy": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clipboard-copy/-/clipboard-copy-4.0.1.tgz",
+      "integrity": "sha512-wOlqdqziE/NNTUJsfSgXmBMIrYmfd5V0HCGsR8uAKHcg+h9NENWINcfRjtWGU77wDHC8B8ijV4hMTGYbrKovng==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -4970,11 +4979,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -6629,14 +6633,6 @@
       "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
       "dev": true
-    },
-    "node_modules/good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
-      "dependencies": {
-        "delegate": "^3.1.2"
-      }
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -11594,11 +11590,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA=="
-    },
     "node_modules/select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -13112,11 +13103,6 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
-    },
-    "node_modules/tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -17409,15 +17395,10 @@
         "string-width": "^5.0.0"
       }
     },
-    "clipboard": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
-      "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
-      "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
+    "clipboard-copy": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clipboard-copy/-/clipboard-copy-4.0.1.tgz",
+      "integrity": "sha512-wOlqdqziE/NNTUJsfSgXmBMIrYmfd5V0HCGsR8uAKHcg+h9NENWINcfRjtWGU77wDHC8B8ijV4hMTGYbrKovng=="
     },
     "cliui": {
       "version": "8.0.1",
@@ -17817,11 +17798,6 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
-    },
-    "delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "depd": {
       "version": "2.0.0",
@@ -19070,14 +19046,6 @@
       "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
       "dev": true
-    },
-    "good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
-      "requires": {
-        "delegate": "^3.1.2"
-      }
     },
     "gopd": {
       "version": "1.0.1",
@@ -22694,11 +22662,6 @@
         "ajv-keywords": "^3.5.2"
       }
     },
-    "select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA=="
-    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -23859,11 +23822,6 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
-    },
-    "tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   "repository": "aframevr/aframe-inspector",
   "license": "MIT",
   "dependencies": {
+    "@fortawesome/free-solid-svg-icons": "^6.5.1",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "classnames": "^2.3.2",
     "clipboard": "^2.0.11",
     "lodash.debounce": "^4.0.8",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "classnames": "^2.3.2",
-    "clipboard": "^2.0.11",
+    "clipboard-copy": "^4.0.1",
     "lodash.debounce": "^4.0.8",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/src/components/EntityRepresentation.js
+++ b/src/components/EntityRepresentation.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  faCamera,
+  faCube,
+  faFont,
+  faLightbulb
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+const ICONS = {
+  camera: <FontAwesomeIcon icon={faCamera} title="camera" />,
+  mesh: <FontAwesomeIcon icon={faCube} title="mesh" />,
+  light: <FontAwesomeIcon icon={faLightbulb} title="light" />,
+  text: <FontAwesomeIcon icon={faFont} title="text" />
+};
+
+export default class EntityRepresentation extends React.Component {
+  static propTypes = {
+    entity: PropTypes.object,
+    onDoubleClick: PropTypes.func
+  };
+
+  render() {
+    const entity = this.props.entity;
+    const onDoubleClick = this.props.onDoubleClick;
+
+    if (!entity) {
+      return null;
+    }
+
+    // Icons.
+    const icons = [];
+    for (let objType in ICONS) {
+      if (!entity.getObject3D(objType)) {
+        continue;
+      }
+      icons.push(<span key={objType}>&nbsp;{ICONS[objType]}</span>);
+    }
+
+    // Name.
+    let entityName = entity.id;
+    let type = 'id';
+    if (!entity.isScene && !entityName && entity.getAttribute('class')) {
+      entityName = entity.getAttribute('class').split(' ')[0];
+      type = 'class';
+    } else if (!entity.isScene && !entityName && entity.getAttribute('mixin')) {
+      entityName = entity.getAttribute('mixin').split(' ')[0];
+      type = 'mixin';
+    }
+
+    return (
+      <span className="entityPrint" onDoubleClick={onDoubleClick}>
+        <span className="entityTagName">
+          {'<' + entity.tagName.toLowerCase()}
+        </span>
+        {entityName && (
+          <span className="entityName" data-entity-name-type={type}>
+            &nbsp;{entityName}
+          </span>
+        )}
+        {icons.length > 0 && <span className="entityIcons">{icons}</span>}
+        <span className="entityCloseTag">{'>'}</span>
+      </span>
+    );
+  }
+}

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Events from '../lib/Events';
 import ComponentsSidebar from './components/Sidebar';
 import ModalTextures from './modals/ModalTextures';
@@ -7,14 +9,8 @@ import SceneGraph from './scenegraph/SceneGraph';
 import CameraToolbar from './viewport/CameraToolbar';
 import TransformToolbar from './viewport/TransformToolbar';
 import ViewportHUD from './viewport/ViewportHUD';
-import { injectCSS } from '../lib/utils';
 
 THREE.ImageUtils.crossOrigin = '';
-
-// Megahack to include font-awesome.
-injectCSS(
-  'https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css'
-);
 
 export default class Main extends React.Component {
   constructor(props) {
@@ -124,9 +120,10 @@ export default class Main extends React.Component {
           onClick={() => {
             Events.emit('togglesidebar', { which: 'attributes' });
           }}
-          className="fa fa-plus"
           title="Show components"
-        />
+        >
+          <FontAwesomeIcon icon={faPlus} />
+        </a>
       </div>
     );
   }
@@ -141,9 +138,10 @@ export default class Main extends React.Component {
           onClick={() => {
             Events.emit('togglesidebar', { which: 'scenegraph' });
           }}
-          className="fa fa-plus"
           title="Show scenegraph"
-        />
+        >
+          <FontAwesomeIcon icon={faPlus} />
+        </a>
       </div>
     );
   }

--- a/src/components/components/CommonComponents.js
+++ b/src/components/components/CommonComponents.js
@@ -13,7 +13,7 @@ import {
   printEntity
 } from '../../lib/entity';
 import Events from '../../lib/Events';
-import Clipboard from 'clipboard';
+import copy from 'clipboard-copy';
 import { saveBlob } from '../../lib/utils';
 import GLTFIcon from '../../../assets/gltf.svg';
 
@@ -42,15 +42,6 @@ export default class CommonComponents extends React.Component {
       ) {
         this.forceUpdate();
       }
-    });
-
-    var clipboard = new Clipboard('[data-action="copy-entity-to-clipboard"]', {
-      text: (trigger) => {
-        return getEntityClipboardRepresentation(this.props.entity);
-      }
-    });
-    clipboard.on('error', (e) => {
-      // @todo Show the error on the UI
     });
   }
 
@@ -117,8 +108,12 @@ export default class CommonComponents extends React.Component {
         </a>
         <a
           title="Copy entity HTML to clipboard"
-          data-action="copy-entity-to-clipboard"
           className="button"
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            copy(getEntityClipboardRepresentation(this.props.entity));
+          }}
         >
           <FontAwesomeIcon icon={faClipboard} />
         </a>

--- a/src/components/components/CommonComponents.js
+++ b/src/components/components/CommonComponents.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { faClipboard } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { InputWidget } from '../widgets';
 import DEFAULT_COMPONENTS from './DefaultComponents';
 import PropertyRow from './PropertyRow';
@@ -116,8 +118,10 @@ export default class CommonComponents extends React.Component {
         <a
           title="Copy entity HTML to clipboard"
           data-action="copy-entity-to-clipboard"
-          className="button fa fa-clipboard"
-        />
+          className="button"
+        >
+          <FontAwesomeIcon icon={faClipboard} />
+        </a>
       </div>
     );
 

--- a/src/components/components/CommonComponents.js
+++ b/src/components/components/CommonComponents.js
@@ -9,9 +9,9 @@ import Collapsible from '../Collapsible';
 import Mixins from './Mixins';
 import {
   updateEntity,
-  getEntityClipboardRepresentation,
-  printEntity
+  getEntityClipboardRepresentation
 } from '../../lib/entity';
+import EntityRepresentation from '../EntityRepresentation';
 import Events from '../../lib/Events';
 import copy from 'clipboard-copy';
 import { saveBlob } from '../../lib/utils';
@@ -123,7 +123,7 @@ export default class CommonComponents extends React.Component {
     return (
       <Collapsible id="componentEntityHeader" className="commonComponents">
         <div className="collapsible-header">
-          {printEntity(entity)}
+          <EntityRepresentation entity={entity} />
           {entityButtons}
         </div>
         <div className="collapsible-content">

--- a/src/components/components/Component.js
+++ b/src/components/components/Component.js
@@ -4,7 +4,7 @@ import { faClipboard, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import PropertyRow from './PropertyRow';
 import Collapsible from '../Collapsible';
-import Clipboard from 'clipboard';
+import copy from 'clipboard-copy';
 import { getComponentClipboardRepresentation } from '../../lib/entity';
 import Events from '../../lib/Events';
 
@@ -30,25 +30,6 @@ export default class Component extends React.Component {
   }
 
   componentDidMount() {
-    var clipboard = new Clipboard(
-      '[data-action="copy-component-to-clipboard"]',
-      {
-        text: (trigger) => {
-          var componentName = trigger
-            .getAttribute('data-component')
-            .toLowerCase();
-          return getComponentClipboardRepresentation(
-            this.state.entity,
-            componentName
-          );
-        }
-      }
-    );
-    clipboard.on('error', (e) => {
-      // @todo Show the error in the UI
-      console.error(e);
-    });
-
     Events.on('entityupdate', (detail) => {
       if (detail.entity !== this.props.entity) {
         return;
@@ -140,9 +121,17 @@ export default class Component extends React.Component {
           <div className="componentHeaderActions">
             <a
               title="Copy to clipboard"
-              data-action="copy-component-to-clipboard"
-              data-component={subComponentName || componentName}
               className="button"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                copy(
+                  getComponentClipboardRepresentation(
+                    this.state.entity,
+                    (subComponentName || componentName).toLowerCase()
+                  )
+                );
+              }}
             >
               <FontAwesomeIcon icon={faClipboard} />
             </a>

--- a/src/components/components/Component.js
+++ b/src/components/components/Component.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { faClipboard, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import PropertyRow from './PropertyRow';
 import Collapsible from '../Collapsible';
 import Clipboard from 'clipboard';
@@ -140,13 +142,17 @@ export default class Component extends React.Component {
               title="Copy to clipboard"
               data-action="copy-component-to-clipboard"
               data-component={subComponentName || componentName}
-              className="button fa fa-clipboard"
-            />
+              className="button"
+            >
+              <FontAwesomeIcon icon={faClipboard} />
+            </a>
             <a
               title="Remove component"
-              className="button fa fa-trash-o"
+              className="button"
               onClick={this.removeComponent}
-            />
+            >
+              <FontAwesomeIcon icon={faTrashAlt} />
+            </a>
           </div>
         </div>
         <div className="collapsible-content">{this.renderPropertyRows()}</div>

--- a/src/components/modals/ModalTextures.js
+++ b/src/components/modals/ModalTextures.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { faSearch } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Events from '../../lib/Events';
 import Modal from './Modal';
 import { insertNewAsset } from '../../lib/assetsUtils';
@@ -325,7 +327,7 @@ export default class ModalTextures extends React.Component {
                       value={this.state.filterText}
                       onChange={this.onChangeFilter}
                     />
-                    <span className="fa fa-search" />
+                    <FontAwesomeIcon icon={faSearch} />
                   </div>
                   <ul ref={this.registryGallery} className="gallery">
                     {this.renderRegistryImages()}

--- a/src/components/scenegraph/Entity.js
+++ b/src/components/scenegraph/Entity.js
@@ -1,6 +1,15 @@
 /* eslint-disable react/no-danger */
 import React from 'react';
 import PropTypes from 'prop-types';
+import {
+  faCaretDown,
+  faCaretRight,
+  faClone,
+  faEye,
+  faEyeSlash,
+  faTrashAlt
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classNames from 'classnames';
 import Events from '../../lib/Events';
 import { printEntity, removeEntity, cloneEntity } from '../../lib/entity';
@@ -46,8 +55,10 @@ export default class Entity extends React.Component {
         <a
           onClick={() => cloneEntity(entity)}
           title="Clone entity"
-          className="button fa fa-clone"
-        />
+          className="button"
+        >
+          <FontAwesomeIcon icon={faClone} />
+        </a>
       );
     const removeButton =
       tagName === 'a-scene' ? null : (
@@ -57,8 +68,10 @@ export default class Entity extends React.Component {
             removeEntity(entity);
           }}
           title="Remove entity"
-          className="button fa fa-trash"
-        />
+          className="button"
+        >
+          <FontAwesomeIcon icon={faTrashAlt} />
+        </a>
       );
 
     // Add spaces depending on depth.
@@ -68,10 +81,14 @@ export default class Entity extends React.Component {
       collapse = (
         <span
           onClick={() => this.props.toggleExpandedCollapsed(entity)}
-          className={`collapsespace fa ${
-            isExpanded ? 'fa-caret-down' : 'fa-caret-right'
-          }`}
-        />
+          className="collapsespace"
+        >
+          {isExpanded ? (
+            <FontAwesomeIcon icon={faCaretDown} />
+          ) : (
+            <FontAwesomeIcon icon={faCaretRight} />
+          )}
+        </span>
       );
     } else {
       collapse = <span className="collapsespace" />;
@@ -83,11 +100,13 @@ export default class Entity extends React.Component {
         ? entity.object3D.visible
         : entity.getAttribute('visible');
     const visibilityButton = (
-      <i
-        title="Toggle entity visibility"
-        className={'fa ' + (visible ? 'fa-eye' : 'fa-eye-slash')}
-        onClick={this.toggleVisibility}
-      />
+      <i title="Toggle entity visibility" onClick={this.toggleVisibility}>
+        {visible ? (
+          <FontAwesomeIcon icon={faEye} />
+        ) : (
+          <FontAwesomeIcon icon={faEyeSlash} />
+        )}
+      </i>
     );
 
     // Class name.

--- a/src/components/scenegraph/Entity.js
+++ b/src/components/scenegraph/Entity.js
@@ -11,8 +11,9 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classNames from 'classnames';
+import { removeEntity, cloneEntity } from '../../lib/entity';
+import EntityRepresentation from '../EntityRepresentation';
 import Events from '../../lib/Events';
-import { printEntity, removeEntity, cloneEntity } from '../../lib/entity';
 
 export default class Entity extends React.Component {
   static propTypes = {
@@ -126,7 +127,10 @@ export default class Entity extends React.Component {
             dangerouslySetInnerHTML={{ __html: pad }}
           />
           {collapse}
-          {printEntity(entity, this.onDoubleClick)}
+          <EntityRepresentation
+            entity={entity}
+            onDoubleClick={this.onDoubleClick}
+          />
         </span>
         <span className="entityActions">
           {cloneButton}

--- a/src/components/scenegraph/SceneGraph.js
+++ b/src/components/scenegraph/SceneGraph.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-unused-vars, react/no-danger */
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
+import { faSearch, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import debounce from 'lodash.debounce';
 
 import Entity from './Entity';
@@ -281,7 +283,9 @@ export default class SceneGraph extends React.Component {
     }
 
     const clearFilter = this.state.filter ? (
-      <a onClick={this.clearFilter} className="button fa fa-times" />
+      <a onClick={this.clearFilter} className="button">
+        <FontAwesomeIcon icon={faTimes} />
+      </a>
     ) : null;
 
     return (
@@ -297,7 +301,7 @@ export default class SceneGraph extends React.Component {
               value={this.state.filter}
             />
             {clearFilter}
-            {!this.state.filter && <span className="fa fa-search" />}
+            {!this.state.filter && <FontAwesomeIcon icon={faSearch} />}
           </div>
         </div>
         <div

--- a/src/components/scenegraph/Toolbar.js
+++ b/src/components/scenegraph/Toolbar.js
@@ -1,7 +1,11 @@
 import React from 'react';
-import { faPlus, faPause, faPlay } from '@fortawesome/free-solid-svg-icons';
+import {
+  faPlus,
+  faPause,
+  faPlay,
+  faFloppyDisk
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import classNames from 'classnames';
 import Events from '../../lib/Events';
 import { saveBlob } from '../../lib/utils';
 import GLTFIcon from '../../../assets/gltf.svg';
@@ -97,11 +101,6 @@ export default class Toolbar extends React.Component {
   };
 
   render() {
-    const watcherClassNames = classNames({
-      button: true,
-      fa: true,
-      'fa-save': true
-    });
     const watcherTitle = 'Write changes with aframe-watcher.';
 
     return (
@@ -134,10 +133,12 @@ export default class Toolbar extends React.Component {
             <img src={GLTFIcon} />
           </a>
           <a
-            className={watcherClassNames}
+            className="button"
             title={watcherTitle}
             onClick={this.writeChanges}
-          />
+          >
+            <FontAwesomeIcon icon={faFloppyDisk} />
+          </a>
         </div>
       </div>
     );

--- a/src/components/scenegraph/Toolbar.js
+++ b/src/components/scenegraph/Toolbar.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { faPlus, faPause, faPlay } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classNames from 'classnames';
 import Events from '../../lib/Events';
 import { saveBlob } from '../../lib/utils';
@@ -106,18 +108,24 @@ export default class Toolbar extends React.Component {
       <div id="toolbar">
         <div className="toolbarActions">
           <a
-            className="button fa fa-plus"
+            className="button"
             title="Add a new entity"
             onClick={this.addEntity}
-          />
+          >
+            <FontAwesomeIcon icon={faPlus} />
+          </a>
           <a
             id="playPauseScene"
-            className={
-              'button fa ' + (this.state.isPlaying ? 'fa-pause' : 'fa-play')
-            }
+            className="button"
             title={this.state.isPlaying ? 'Pause scene' : 'Resume scene'}
             onClick={this.toggleScenePlaying}
-          ></a>
+          >
+            {this.state.isPlaying ? (
+              <FontAwesomeIcon icon={faPause} />
+            ) : (
+              <FontAwesomeIcon icon={faPlay} />
+            )}
+          </a>
           <a
             className="gltfIcon"
             title="Export to GLTF"

--- a/src/components/viewport/TransformToolbar.js
+++ b/src/components/viewport/TransformToolbar.js
@@ -1,11 +1,20 @@
 import React from 'react';
+import {
+  faArrowsAlt,
+  faRotateRight,
+  faUpRightAndDownLeftFromCenter
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classNames from 'classnames';
 import Events from '../../lib/Events';
 
 var TransformButtons = [
-  { value: 'translate', icon: 'fa-arrows-alt' },
-  { value: 'rotate', icon: 'fa-repeat' },
-  { value: 'scale', icon: 'fa-expand' }
+  { value: 'translate', icon: <FontAwesomeIcon icon={faArrowsAlt} /> },
+  { value: 'rotate', icon: <FontAwesomeIcon icon={faRotateRight} /> },
+  {
+    value: 'scale',
+    icon: <FontAwesomeIcon icon={faUpRightAndDownLeftFromCenter} />
+  }
 ];
 
 export default class TransformToolbar extends React.Component {
@@ -48,8 +57,6 @@ export default class TransformToolbar extends React.Component {
         var selected = option.value === this.state.selectedTransform;
         var classes = classNames({
           button: true,
-          fa: true,
-          [option.icon]: true,
           active: selected
         });
 
@@ -59,7 +66,9 @@ export default class TransformToolbar extends React.Component {
             key={i}
             onClick={this.changeTransformMode.bind(this, option.value)}
             className={classes}
-          />
+          >
+            {option.icon}
+          </a>
         );
       }.bind(this)
     );

--- a/src/components/viewport/ViewportHUD.js
+++ b/src/components/viewport/ViewportHUD.js
@@ -1,6 +1,6 @@
 import React from 'react';
+import EntityRepresentation from '../EntityRepresentation';
 import Events from '../../lib/Events';
-import { printEntity } from '../../lib/entity';
 
 export default class ViewportHUD extends React.Component {
   constructor(props) {
@@ -24,7 +24,9 @@ export default class ViewportHUD extends React.Component {
   render() {
     return (
       <div id="viewportHud">
-        <p>{printEntity(this.state.hoveredEntity)}</p>
+        <p>
+          <EntityRepresentation entity={this.state.hoveredEntity} />
+        </p>
       </div>
     );
   }

--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -519,61 +519,6 @@ export function getComponentClipboardRepresentation(entity, componentName) {
 }
 
 /**
- * Entity representation.
- */
-const ICONS = {
-  camera: 'fa-camera',
-  mesh: 'fa-cube',
-  light: 'fa-lightbulb-o',
-  text: 'fa-font'
-};
-export function printEntity(entity, onDoubleClick) {
-  if (!entity) {
-    return '';
-  }
-
-  // Icons.
-  let icons = '';
-  for (let objType in ICONS) {
-    if (!entity.getObject3D(objType)) {
-      continue;
-    }
-    icons += `&nbsp;<i class="fa ${ICONS[objType]}" title="${objType}"></i>`;
-  }
-
-  // Name.
-  let entityName = entity.id;
-  let type = 'id';
-  if (!entity.isScene && !entityName && entity.getAttribute('class')) {
-    entityName = entity.getAttribute('class').split(' ')[0];
-    type = 'class';
-  } else if (!entity.isScene && !entityName && entity.getAttribute('mixin')) {
-    entityName = entity.getAttribute('mixin').split(' ')[0];
-    type = 'mixin';
-  }
-
-  return (
-    <span className="entityPrint" onDoubleClick={onDoubleClick}>
-      <span className="entityTagName">
-        {'<' + entity.tagName.toLowerCase()}
-      </span>
-      {entityName && (
-        <span className="entityName" data-entity-name-type={type}>
-          &nbsp;{entityName}
-        </span>
-      )}
-      {!!icons && (
-        <span
-          className="entityIcons"
-          dangerouslySetInnerHTML={{ __html: icons }}
-        />
-      )}
-      <span className="entityCloseTag">{'>'}</span>
-    </span>
-  );
-}
-
-/**
  * Helper function to add a new entity with a list of components
  * @param  {object} definition Entity definition to add:
  *   {element: 'a-entity', components: {geometry: 'primitive:box'}}

--- a/src/style/components.styl
+++ b/src/style/components.styl
@@ -238,7 +238,7 @@ a.help-linkhover
 #componentEntityHeader .gltfIcon img
   top 0
 
-.fa
+svg
   color $white
   &:hover
     color $primary

--- a/src/style/scenegraph.styl
+++ b/src/style/scenegraph.styl
@@ -42,14 +42,14 @@
     &.novisible
       &.active
         span,
-        .fa,
+        svg,
         .collapsespace,
         .id
           color #999
 
       &:not(.active)
         span,
-        .fa,
+        svg,
         .collapsespace,
         .id
           color #626262
@@ -69,13 +69,13 @@
       font-size 12px
       margin-left 6px
 
-  .fa
+  svg
     color #CCC
 
-  .entityActions .fa:hover
+  .entityActions svg:hover
     color $primary
 
-  .active .fa
+  .active svg
     color #FAFAFA
 
   .id
@@ -109,15 +109,10 @@
       text-indent 10px
       width 216px
 
-    .fa-search
+    svg
       position absolute
       right 14px
-      top 8px
-
-    .fa-times
-      position absolute
-      right 15px
-      top 9px
+      top 10px
 
   .outliner
     background $bg

--- a/src/style/textureModal.styl
+++ b/src/style/textureModal.styl
@@ -84,11 +84,6 @@
   min-height 60px
   padding 3px 10px
 
-.gallery li .button.fa-external-link
-  margin-left 136px
-  margin-top 5px
-  position fixed
-
 .preview
   padding 10px
   width 150px
@@ -179,26 +174,21 @@
 .texture canvas + input
   margin-left 5px
 
-.texture .fa
+.texture svg
   padding-right 5px
-
-.texture .fa-external-link
-  font-size 14px
-  padding-top 2px
 
 .uploader-normal-button .hidden
   display none
 
-.gallery a.fa.texture-link
-  box-shadow 0 0 14px -1px rgba(0, 0, 0, 0.75)
-  position fixed
-
 .assets.search
+  position relative
   margin-top 10px
   width 200px
 
-.assets.search .fa-search
-  top 7px
+.assets.search svg
+  position absolute
+  right 0px
+  top 5px
 
 .new_asset_options
   margin 10px

--- a/src/style/viewport.styl
+++ b/src/style/viewport.styl
@@ -15,27 +15,31 @@
   top 0
 
 .toolbarButtons
-  position relative
+  display flex
+  align-items center
+  gap 6px
 
   *
-    margin-left 0
-    padding 8px
+    margin-left 0 !important
     vertical-align middle
 
   a.button
-    margin 0 6px 0 0
-    &:not(.active):hover
+    & svg
+      padding 8px
+
+    &:not(.active) svg:hover
       background-color $grayhover
 
-  .active
+  .active svg
     background-color $primary
     color #fff
 
-  .active:hover
+  .active:hover svg
     color #fff !important
 
 .local-transform
   padding-left 10px
+  padding-right 20px
 
 .local-transform label
   color $lightgray


### PR DESCRIPTION
This closes #692
Some icons slightly changed.

Remaining to do:
- [x] Regression for the collapsible panel when clicking on clipboard icon
- [x] save icon
- [x] icons for types camera: 'fa-camera', mesh: 'fa-cube', light: 'fa-lightbulb-o', text: 'fa-font'