### PR TITLE
Reduce bundle size after the fontawesome icons changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "^6.5.1",
-        "classnames": "^2.3.2",
         "clipboard-copy": "^4.0.1",
+        "clsx": "^2.1.0",
         "lodash.debounce": "^4.0.8",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
@@ -4379,11 +4379,6 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
-    "node_modules/classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
-    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -4507,6 +4502,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -17322,11 +17325,6 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
-    "classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
-    },
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -17414,6 +17412,11 @@
           }
         }
       }
+    },
+    "clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg=="
     },
     "co": {
       "version": "4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "^6.5.1",
-        "@fortawesome/react-fontawesome": "^0.2.0",
         "classnames": "^2.3.2",
         "clipboard-copy": "^4.0.1",
         "lodash.debounce": "^4.0.8",
@@ -2040,19 +2039,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
-      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
-      "hasInstallScript": true,
-      "peer": true,
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.5.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@fortawesome/free-solid-svg-icons": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",
@@ -2063,18 +2049,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/react-fontawesome": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
-      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
-      "dependencies": {
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
-        "react": ">=16.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -15477,29 +15451,12 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
       "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A=="
     },
-    "@fortawesome/fontawesome-svg-core": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
-      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
-      "peer": true,
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "6.5.1"
-      }
-    },
     "@fortawesome/free-solid-svg-icons": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",
       "integrity": "sha512-S1PPfU3mIJa59biTtXJz1oI0+KAXW6bkAb31XKhxdxtuXDiUIFsih4JR1v5BbxY7hVHsD1RKq+jRkVRaf773NQ==",
       "requires": {
         "@fortawesome/fontawesome-common-types": "6.5.1"
-      }
-    },
-    "@fortawesome/react-fontawesome": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
-      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
-      "requires": {
-        "prop-types": "^15.8.1"
       }
     },
     "@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "license": "MIT",
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
-    "classnames": "^2.3.2",
     "clipboard-copy": "^4.0.1",
+    "clsx": "^2.1.0",
     "lodash.debounce": "^4.0.8",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "license": "MIT",
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
-    "@fortawesome/react-fontawesome": "^0.2.0",
     "classnames": "^2.3.2",
     "clipboard-copy": "^4.0.1",
     "lodash.debounce": "^4.0.8",

--- a/src/components/AwesomeIcon.js
+++ b/src/components/AwesomeIcon.js
@@ -1,0 +1,53 @@
+/*
+  Use <AwesomeIcon icon={faEye} /> instead of <FontAwesomeIcon icon={faEye} /> from @fortawesome/react-fontawesome
+  Using FontAwesomeIcon component adds 66 kB minified to the bundle.
+  Our AwesomeIcon does the same but less than 2 kB minified.
+  svg-inline--fa class has been added to lib.styl
+*/
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function asIcon(icon) {
+  const width = icon[0];
+  const height = icon[1];
+  const vectorData = icon[4];
+  let element;
+
+  if (Array.isArray(vectorData)) {
+    element = (
+      <g>
+        {vectorData.map((pathData, index) => (
+          <path key={index} fill="currentColor" d={pathData} />
+        ))}
+      </g>
+    );
+  } else {
+    element = <path fill="currentColor" d={vectorData} />;
+  }
+
+  return {
+    width: width,
+    height: height,
+    icon: element
+  };
+}
+
+export class AwesomeIcon extends React.Component {
+  static propTypes = {
+    icon: PropTypes.object.isRequired
+  };
+
+  render() {
+    const { width, height, icon } = asIcon(this.props.icon.icon);
+    return (
+      <svg
+        role="img"
+        className={`svg-inline--fa fa-${this.props.icon.iconName}`}
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox={`0 0 ${width} ${height}`}
+      >
+        {icon}
+      </svg>
+    );
+  }
+}

--- a/src/components/Collapsible.js
+++ b/src/components/Collapsible.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 export default class Collapsible extends React.Component {
   static propTypes = {
@@ -37,9 +37,9 @@ export default class Collapsible extends React.Component {
     if (this.props.className) {
       rootClassNames[this.props.className] = true;
     }
-    const rootClasses = classNames(rootClassNames);
+    const rootClasses = clsx(rootClassNames);
 
-    const contentClasses = classNames({
+    const contentClasses = clsx({
       content: true,
       hide: this.state.collapsed
     });

--- a/src/components/EntityRepresentation.js
+++ b/src/components/EntityRepresentation.js
@@ -6,13 +6,29 @@ import {
   faFont,
   faLightbulb
 } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { AwesomeIcon } from './AwesomeIcon';
 
 const ICONS = {
-  camera: <FontAwesomeIcon icon={faCamera} title="camera" />,
-  mesh: <FontAwesomeIcon icon={faCube} title="mesh" />,
-  light: <FontAwesomeIcon icon={faLightbulb} title="light" />,
-  text: <FontAwesomeIcon icon={faFont} title="text" />
+  camera: (
+    <i title="camera">
+      <AwesomeIcon icon={faCamera} />
+    </i>
+  ),
+  mesh: (
+    <i title="mesh">
+      <AwesomeIcon icon={faCube} />
+    </i>
+  ),
+  light: (
+    <i title="light">
+      <AwesomeIcon icon={faLightbulb} />
+    </i>
+  ),
+  text: (
+    <i title="text">
+      <AwesomeIcon icon={faFont} />
+    </i>
+  )
 };
 
 export default class EntityRepresentation extends React.Component {

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { AwesomeIcon } from './AwesomeIcon';
 import Events from '../lib/Events';
 import ComponentsSidebar from './components/Sidebar';
 import ModalTextures from './modals/ModalTextures';
@@ -122,7 +122,7 @@ export default class Main extends React.Component {
           }}
           title="Show components"
         >
-          <FontAwesomeIcon icon={faPlus} />
+          <AwesomeIcon icon={faPlus} />
         </a>
       </div>
     );
@@ -140,7 +140,7 @@ export default class Main extends React.Component {
           }}
           title="Show scenegraph"
         >
-          <FontAwesomeIcon icon={faPlus} />
+          <AwesomeIcon icon={faPlus} />
         </a>
       </div>
     );

--- a/src/components/components/CommonComponents.js
+++ b/src/components/components/CommonComponents.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { faClipboard } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { AwesomeIcon } from '../AwesomeIcon';
 import { InputWidget } from '../widgets';
 import DEFAULT_COMPONENTS from './DefaultComponents';
 import PropertyRow from './PropertyRow';
@@ -115,7 +115,7 @@ export default class CommonComponents extends React.Component {
             copy(getEntityClipboardRepresentation(this.props.entity));
           }}
         >
-          <FontAwesomeIcon icon={faClipboard} />
+          <AwesomeIcon icon={faClipboard} />
         </a>
       </div>
     );

--- a/src/components/components/Component.js
+++ b/src/components/components/Component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { faClipboard, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { AwesomeIcon } from '../AwesomeIcon';
 import PropertyRow from './PropertyRow';
 import Collapsible from '../Collapsible';
 import copy from 'clipboard-copy';
@@ -133,14 +133,14 @@ export default class Component extends React.Component {
                 );
               }}
             >
-              <FontAwesomeIcon icon={faClipboard} />
+              <AwesomeIcon icon={faClipboard} />
             </a>
             <a
               title="Remove component"
               className="button"
               onClick={this.removeComponent}
             >
-              <FontAwesomeIcon icon={faTrashAlt} />
+              <AwesomeIcon icon={faTrashAlt} />
             </a>
           </div>
         </div>

--- a/src/components/components/PropertyRow.js
+++ b/src/components/components/PropertyRow.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-prototype-builtins */
 import React from 'react';
-import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import clsx from 'clsx';
 
 import BooleanWidget from '../widgets/BooleanWidget';
 import ColorWidget from '../widgets/ColorWidget';
@@ -119,7 +119,7 @@ export default class PropertyRow extends React.Component {
     const title =
       props.name + '\n - type: ' + props.schema.type + '\n - value: ' + value;
 
-    const className = classNames({
+    const className = clsx({
       propertyRow: true,
       propertyRowDefined: props.isSingle
         ? !!props.entity.getDOMAttribute(props.componentname)

--- a/src/components/modals/ModalTextures.js
+++ b/src/components/modals/ModalTextures.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { AwesomeIcon } from '../AwesomeIcon';
 import Events from '../../lib/Events';
 import Modal from './Modal';
 import { insertNewAsset } from '../../lib/assetsUtils';
@@ -327,7 +327,7 @@ export default class ModalTextures extends React.Component {
                       value={this.state.filterText}
                       onChange={this.onChangeFilter}
                     />
-                    <FontAwesomeIcon icon={faSearch} />
+                    <AwesomeIcon icon={faSearch} />
                   </div>
                   <ul ref={this.registryGallery} className="gallery">
                     {this.renderRegistryImages()}

--- a/src/components/scenegraph/Entity.js
+++ b/src/components/scenegraph/Entity.js
@@ -10,7 +10,7 @@ import {
   faTrashAlt
 } from '@fortawesome/free-solid-svg-icons';
 import { AwesomeIcon } from '../AwesomeIcon';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { removeEntity, cloneEntity } from '../../lib/entity';
 import EntityRepresentation from '../EntityRepresentation';
 import Events from '../../lib/Events';
@@ -111,7 +111,7 @@ export default class Entity extends React.Component {
     );
 
     // Class name.
-    const className = classNames({
+    const className = clsx({
       active: this.props.isSelected,
       entity: true,
       novisible: !visible,

--- a/src/components/scenegraph/Entity.js
+++ b/src/components/scenegraph/Entity.js
@@ -9,7 +9,7 @@ import {
   faEyeSlash,
   faTrashAlt
 } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { AwesomeIcon } from '../AwesomeIcon';
 import classNames from 'classnames';
 import { removeEntity, cloneEntity } from '../../lib/entity';
 import EntityRepresentation from '../EntityRepresentation';
@@ -58,7 +58,7 @@ export default class Entity extends React.Component {
           title="Clone entity"
           className="button"
         >
-          <FontAwesomeIcon icon={faClone} />
+          <AwesomeIcon icon={faClone} />
         </a>
       );
     const removeButton =
@@ -71,7 +71,7 @@ export default class Entity extends React.Component {
           title="Remove entity"
           className="button"
         >
-          <FontAwesomeIcon icon={faTrashAlt} />
+          <AwesomeIcon icon={faTrashAlt} />
         </a>
       );
 
@@ -85,9 +85,9 @@ export default class Entity extends React.Component {
           className="collapsespace"
         >
           {isExpanded ? (
-            <FontAwesomeIcon icon={faCaretDown} />
+            <AwesomeIcon icon={faCaretDown} />
           ) : (
-            <FontAwesomeIcon icon={faCaretRight} />
+            <AwesomeIcon icon={faCaretRight} />
           )}
         </span>
       );
@@ -103,9 +103,9 @@ export default class Entity extends React.Component {
     const visibilityButton = (
       <i title="Toggle entity visibility" onClick={this.toggleVisibility}>
         {visible ? (
-          <FontAwesomeIcon icon={faEye} />
+          <AwesomeIcon icon={faEye} />
         ) : (
-          <FontAwesomeIcon icon={faEyeSlash} />
+          <AwesomeIcon icon={faEyeSlash} />
         )}
       </i>
     );

--- a/src/components/scenegraph/SceneGraph.js
+++ b/src/components/scenegraph/SceneGraph.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { faSearch, faTimes } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { AwesomeIcon } from '../AwesomeIcon';
 import debounce from 'lodash.debounce';
 
 import Entity from './Entity';
@@ -284,7 +284,7 @@ export default class SceneGraph extends React.Component {
 
     const clearFilter = this.state.filter ? (
       <a onClick={this.clearFilter} className="button">
-        <FontAwesomeIcon icon={faTimes} />
+        <AwesomeIcon icon={faTimes} />
       </a>
     ) : null;
 
@@ -301,7 +301,7 @@ export default class SceneGraph extends React.Component {
               value={this.state.filter}
             />
             {clearFilter}
-            {!this.state.filter && <FontAwesomeIcon icon={faSearch} />}
+            {!this.state.filter && <AwesomeIcon icon={faSearch} />}
           </div>
         </div>
         <div

--- a/src/components/scenegraph/Toolbar.js
+++ b/src/components/scenegraph/Toolbar.js
@@ -5,7 +5,7 @@ import {
   faPlay,
   faFloppyDisk
 } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { AwesomeIcon } from '../AwesomeIcon';
 import Events from '../../lib/Events';
 import { saveBlob } from '../../lib/utils';
 import GLTFIcon from '../../../assets/gltf.svg';
@@ -111,7 +111,7 @@ export default class Toolbar extends React.Component {
             title="Add a new entity"
             onClick={this.addEntity}
           >
-            <FontAwesomeIcon icon={faPlus} />
+            <AwesomeIcon icon={faPlus} />
           </a>
           <a
             id="playPauseScene"
@@ -120,9 +120,9 @@ export default class Toolbar extends React.Component {
             onClick={this.toggleScenePlaying}
           >
             {this.state.isPlaying ? (
-              <FontAwesomeIcon icon={faPause} />
+              <AwesomeIcon icon={faPause} />
             ) : (
-              <FontAwesomeIcon icon={faPlay} />
+              <AwesomeIcon icon={faPlay} />
             )}
           </a>
           <a
@@ -137,7 +137,7 @@ export default class Toolbar extends React.Component {
             title={watcherTitle}
             onClick={this.writeChanges}
           >
-            <FontAwesomeIcon icon={faFloppyDisk} />
+            <AwesomeIcon icon={faFloppyDisk} />
           </a>
         </div>
       </div>

--- a/src/components/viewport/TransformToolbar.js
+++ b/src/components/viewport/TransformToolbar.js
@@ -4,16 +4,16 @@ import {
   faRotateRight,
   faUpRightAndDownLeftFromCenter
 } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { AwesomeIcon } from '../AwesomeIcon';
 import classNames from 'classnames';
 import Events from '../../lib/Events';
 
 var TransformButtons = [
-  { value: 'translate', icon: <FontAwesomeIcon icon={faArrowsAlt} /> },
-  { value: 'rotate', icon: <FontAwesomeIcon icon={faRotateRight} /> },
+  { value: 'translate', icon: <AwesomeIcon icon={faArrowsAlt} /> },
+  { value: 'rotate', icon: <AwesomeIcon icon={faRotateRight} /> },
   {
     value: 'scale',
-    icon: <FontAwesomeIcon icon={faUpRightAndDownLeftFromCenter} />
+    icon: <AwesomeIcon icon={faUpRightAndDownLeftFromCenter} />
   }
 ];
 

--- a/src/components/viewport/TransformToolbar.js
+++ b/src/components/viewport/TransformToolbar.js
@@ -5,7 +5,7 @@ import {
   faUpRightAndDownLeftFromCenter
 } from '@fortawesome/free-solid-svg-icons';
 import { AwesomeIcon } from '../AwesomeIcon';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import Events from '../../lib/Events';
 
 var TransformButtons = [
@@ -55,7 +55,7 @@ export default class TransformToolbar extends React.Component {
     return TransformButtons.map(
       function (option, i) {
         var selected = option.value === this.state.selectedTransform;
-        var classes = classNames({
+        var classes = clsx({
           button: true,
           active: selected
         });

--- a/src/style/lib.styl
+++ b/src/style/lib.styl
@@ -26,3 +26,16 @@ media--1024() {
     {block}
   }
 }
+
+/* CSS rules from the original FontAwesomeIcon component */
+svg:not(:root).svg-inline--fa, svg:not(:host).svg-inline--fa {
+  overflow: visible;
+  box-sizing: content-box;
+}
+
+.svg-inline--fa {
+  display: inline-block;
+  height: 1em;
+  overflow: visible;
+  vertical-align: -0.125em;
+}


### PR DESCRIPTION
This addresses my comment https://github.com/aframevr/aframe-inspector/pull/706#issuecomment-1952042203 about he unfortunate increase of the bundle size.
When I wanted to do #692 I had in mind a decrease of what need to be downloaded, not an increase. This PR fixes it.

Removing usage of FontAwesomeIcon component and using our own simplified component remove 66 kB.
I also switched from classnames to lighter clsx that is used nowadays in React projects, removing 1 kB.
This PR reduces the minified bundle from 554K to 489K.

Before #706 we had 483K+27K=510K
After #706 and this PR: 489K.
