### PR TITLE
Pass the entity in entityclone event and register loaded listener once

### DIFF
--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -128,10 +128,14 @@ export function cloneEntity(entity) {
   entity.flushToDOM();
 
   const clone = prepareForSerialization(entity);
-  clone.addEventListener('loaded', function () {
-    AFRAME.INSPECTOR.selectEntity(clone);
-    Events.emit('entityclone');
-  });
+  clone.addEventListener(
+    'loaded',
+    function () {
+      AFRAME.INSPECTOR.selectEntity(clone);
+      Events.emit('entityclone', clone);
+    },
+    { once: true }
+  );
 
   // Get a valid unique ID for the entity
   if (entity.id) {
@@ -533,10 +537,14 @@ export function createEntity(definition, cb) {
   }
 
   // Ensure the components are loaded before update the UI
-  entity.addEventListener('loaded', () => {
-    Events.emit('entitycreated', entity);
-    cb(entity);
-  });
+  entity.addEventListener(
+    'loaded',
+    () => {
+      Events.emit('entitycreated', entity);
+      cb(entity);
+    },
+    { once: true }
+  );
 
   AFRAME.scenes[0].appendChild(entity);
 


### PR DESCRIPTION
Pass the entity in entityclone event similar to entitycreated and entityidchange events and register the loaded listener once.

Those changes are changes I'm doing for my own editor/configurator written with solidjs/tailwindcss using aframe-inspector core, and it also benefits 3dstreet editor.