### PR TITLE
Wait for gltf-model to be loaded to show the selectionBox

### DIFF
--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -149,6 +149,15 @@ export function Viewport(inspector) {
       if (object.el.getObject3D('mesh')) {
         selectionBox.setFromObject(object);
         selectionBox.visible = true;
+      } else if (object.el.hasAttribute('gltf-model')) {
+        object.el.addEventListener(
+          'model-loaded',
+          () => {
+            selectionBox.setFromObject(object);
+            selectionBox.visible = true;
+          },
+          { once: true }
+        );
       }
 
       transformControls.attach(object);


### PR DESCRIPTION
When you create an entity with the entitycreate event with components object having a gltf-model, the selectionBox didn't appear. This fixes it.