### PR TITLE
Add optional support for id and class in createEntity definition

### DIFF
--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -520,12 +520,19 @@ export function getComponentClipboardRepresentation(entity, componentName) {
 
 /**
  * Helper function to add a new entity with a list of components
- * @param  {object} definition Entity definition to add:
- *   {element: 'a-entity', components: {geometry: 'primitive:box'}}
+ * @param  {object} definition Entity definition to add, only components is required:
+ *   {element: 'a-entity', id: "hbiuSdYL2", class: "box", components: {geometry: 'primitive:box'}}
  * @return {Element} Entity created
  */
 export function createEntity(definition, cb) {
-  const entity = document.createElement(definition.element);
+  const entity = document.createElement(definition.element || 'a-entity');
+  if (definition.id) {
+    entity.id = definition.id;
+  }
+
+  if (definition.class) {
+    entity.setAttribute('class', definition.class);
+  }
 
   // load default attributes
   for (let attr in definition.components) {


### PR DESCRIPTION
Add optional support for id and class in createEntity definition make element optional, default to a-entity.