### PR TITLE
Support for translationsnapchanged and rotationsnapchanged

### DIFF
--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -134,8 +134,12 @@ export function Viewport(inspector) {
     transformControls.setMode(mode);
   });
 
-  Events.on('snapchanged', (dist) => {
+  Events.on('translationsnapchanged', (dist) => {
     transformControls.setTranslationSnap(dist);
+  });
+
+  Events.on('rotationsnapchanged', (dist) => {
+    transformControls.setRotationSnap(dist);
   });
 
   Events.on('transformspacechanged', (space) => {


### PR DESCRIPTION
Rename snapchanged to translationsnapchanged and add rotationsnapchanged to be able to configure snapping for both translation and rotation.
The current React interface doesn't use this code.