### PR TITLE
Proper cleanup of url and link element in saveBlob

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -97,10 +97,12 @@ export function saveBlob(blob, filename) {
   var link = document.createElement('a');
   link.style.display = 'none';
   document.body.appendChild(link);
-  link.href = URL.createObjectURL(blob);
+  const url = URL.createObjectURL(blob);
+  link.href = url;
   link.download = filename || 'ascene.html';
   link.click();
-  // URL.revokeObjectURL(url); breaks Firefox...
+  URL.revokeObjectURL(url);
+  link.remove();
 }
 
 // Compares 2 vector objects up to size 4


### PR DESCRIPTION
This works fine today on Firefox.