### PR TITLE
Keep the camera position when switching to inspector (fix #607)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,15 @@ edit `index.html` and define before any script tag this global variable:
 ```html
 <script>window.AFRAME_SAMPLE_ASSETS_ROOT = "./sample-assets/";</script>
 ```
+
+## Config overrides
+
+Since A-Frame 1.7.0, the inspector perspective camera position is kept in sync with the A-Frame
+active camera. This means you can move around the scene, toggle the inspector and you will be at the same position.
+If you want to disable that behavior, you can do that by defining a global variable like this:
+
+```html
+<script>
+  window.AFRAME_INSPECTOR_CONFIG = { copyCameraPosition: false };
+</script>
+```

--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,14 @@ import { Shortcuts } from './lib/shortcuts';
 import Main from './components/Main';
 import { initCameras } from './lib/cameras';
 import { createEntity } from './lib/entity';
+import { Config } from './lib/config';
 import { GLTFExporter } from 'three/addons/exporters/GLTFExporter';
 
 import './style/index.styl';
 
-function Inspector() {
+function Inspector(configOverrides) {
   this.assetsLoader = new AssetsLoader();
+  this.config = new Config(configOverrides);
   this.exporters = { gltf: new GLTFExporter() };
   this.history = require('./lib/history');
   this.isFirstOpen = true;
@@ -301,4 +303,4 @@ Inspector.prototype = {
   }
 };
 
-AFRAME.INSPECTOR = new Inspector();
+AFRAME.INSPECTOR = new Inspector(window.AFRAME_INSPECTOR_CONFIG);

--- a/src/lib/cameras.js
+++ b/src/lib/cameras.js
@@ -116,8 +116,23 @@ function setOrthoCamera(camera, dir, ratio) {
   camera.rotation.copy(info.rotation);
 }
 
+/**
+ * Copy position and rotation from source aframe camera to target camera.
+ * Also set center for EditorControls 2m in front of camera.
+ *
+ * @param {Object3D} sourceCamera
+ * @param {Camera} targetCamera
+ */
 export function copyCameraPosition(sourceCamera, targetCamera) {
   sourceCamera.getWorldPosition(targetCamera.position);
   sourceCamera.getWorldQuaternion(targetCamera.quaternion);
   targetCamera.updateMatrixWorld();
+
+  // Set center for EditorControls 2m in front of camera.
+  const worldDirection = new THREE.Vector3();
+  targetCamera.getWorldDirection(worldDirection);
+  const center = targetCamera.position
+    .clone()
+    .addScaledVector(worldDirection, 2);
+  AFRAME.INSPECTOR.controls.center.copy(center);
 }

--- a/src/lib/cameras.js
+++ b/src/lib/cameras.js
@@ -115,3 +115,9 @@ function setOrthoCamera(camera, dir, ratio) {
   camera.position.copy(info.position);
   camera.rotation.copy(info.rotation);
 }
+
+export function copyCameraPosition(sourceCamera, targetCamera) {
+  sourceCamera.getWorldPosition(targetCamera.position);
+  sourceCamera.getWorldQuaternion(targetCamera.quaternion);
+  targetCamera.updateMatrixWorld();
+}

--- a/src/lib/cameras.js
+++ b/src/lib/cameras.js
@@ -122,8 +122,9 @@ function setOrthoCamera(camera, dir, ratio) {
  *
  * @param {Object3D} sourceCamera
  * @param {Camera} targetCamera
+ * @param {EditorControls} controls
  */
-export function copyCameraPosition(sourceCamera, targetCamera) {
+export function copyCameraPosition(sourceCamera, targetCamera, controls) {
   sourceCamera.getWorldPosition(targetCamera.position);
   sourceCamera.getWorldQuaternion(targetCamera.quaternion);
   targetCamera.updateMatrixWorld();
@@ -134,5 +135,5 @@ export function copyCameraPosition(sourceCamera, targetCamera) {
   const center = targetCamera.position
     .clone()
     .addScaledVector(worldDirection, 2);
-  AFRAME.INSPECTOR.controls.center.copy(center);
+  controls.center.copy(center);
 }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,0 +1,7 @@
+export function Config(overrides) {
+  return {
+    // Keep the inspector perspective camera position in sync with the A-Frame active camera.
+    copyCameraPosition: true,
+    ...overrides
+  };
+}

--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -2,6 +2,7 @@
 import TransformControls from './TransformControls.js';
 import EditorControls from './EditorControls.js';
 
+import { copyCameraPosition } from './cameras';
 import { initRaycaster } from './raycaster';
 import Events from './Events';
 
@@ -253,6 +254,10 @@ export function Viewport(inspector) {
         .forEach((element) => {
           element.style.display = 'none';
         });
+      copyCameraPosition(
+        inspector.cameras.original.object3D,
+        inspector.cameras.perspective
+      );
     } else {
       disableControls();
       inspector.cameras.original.setAttribute('camera', 'active', 'true');

--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -255,10 +255,12 @@ export function Viewport(inspector) {
         .forEach((element) => {
           element.style.display = 'none';
         });
-      copyCameraPosition(
-        inspector.cameras.original.object3D,
-        inspector.cameras.perspective
-      );
+      if (inspector.config.copyCameraPosition) {
+        copyCameraPosition(
+          inspector.cameras.original.object3D,
+          inspector.cameras.perspective
+        );
+      }
     } else {
       disableControls();
       inspector.cameras.original.setAttribute('camera', 'active', 'true');

--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -108,7 +108,6 @@ export function Viewport(inspector) {
 
   // Controls need to be added *after* main logic.
   const controls = new THREE.EditorControls(camera, inspector.container);
-  inspector.controls = controls; // to be able to change center from camera.js copyCameraPosition function
   controls.center.set(0, 1.6, 0);
   controls.rotationSpeed = 0.0035;
   controls.zoomSpeed = 0.05;
@@ -258,7 +257,8 @@ export function Viewport(inspector) {
       if (inspector.config.copyCameraPosition) {
         copyCameraPosition(
           inspector.cameras.original.object3D,
-          inspector.cameras.perspective
+          inspector.cameras.perspective,
+          controls
         );
       }
     } else {

--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -108,6 +108,7 @@ export function Viewport(inspector) {
 
   // Controls need to be added *after* main logic.
   const controls = new THREE.EditorControls(camera, inspector.container);
+  inspector.controls = controls; // to be able to change center from camera.js copyCameraPosition function
   controls.center.set(0, 1.6, 0);
   controls.rotationSpeed = 0.0035;
   controls.zoomSpeed = 0.05;


### PR DESCRIPTION
Keep the camera position and rotation when opening the inspector.

I have this change for quite some times in my project. When I use the default inspector build in other projects I am so frustrated that the camera position is not kept while opening the inspector.
It seems I am not the only one that wanted this behavior.

This closes #607