### PR TITLE
Fix issue with zoom with mouse wheel jumping when switching camera

### DIFF
--- a/src/lib/cameras.js
+++ b/src/lib/cameras.js
@@ -118,4 +118,5 @@ function setOrthoCamera(camera, dir, ratio) {
   camera.bottom = info.bottom || -10;
   camera.position.copy(info.position);
   camera.rotation.copy(info.rotation);
+  camera.updateProjectionMatrix();
 }


### PR DESCRIPTION
Fix issue with zoom with mouse wheel jumping when switching to an ortho camera and zooming because of missing `camera.updateProjectionMatrix()`