### PR TITLE
[cleanup] Remove unneeded child-attached listener that refreshes raycaster objects

### DIFF
--- a/src/lib/raycaster.js
+++ b/src/lib/raycaster.js
@@ -1,16 +1,15 @@
 import Events from './Events';
-import debounce from 'lodash.debounce';
 
 export function initRaycaster(inspector) {
   // Use cursor="rayOrigin: mouse".
   const mouseCursor = document.createElement('a-entity');
   mouseCursor.setAttribute('id', 'aframeInspectorMouseCursor');
-  mouseCursor.setAttribute('cursor', 'rayOrigin', 'mouse');
-  mouseCursor.setAttribute('data-aframe-inspector', 'true');
   mouseCursor.setAttribute('raycaster', {
     interval: 100,
     objects: 'a-scene :not([data-aframe-inspector])'
   });
+  mouseCursor.setAttribute('cursor', 'rayOrigin', 'mouse');
+  mouseCursor.setAttribute('data-aframe-inspector', 'true');
 
   // Only visible objects.
   const raycaster = mouseCursor.components.raycaster;
@@ -32,13 +31,6 @@ export function initRaycaster(inspector) {
 
   inspector.sceneEl.appendChild(mouseCursor);
   inspector.cursor = mouseCursor;
-
-  inspector.sceneEl.addEventListener(
-    'child-attached',
-    debounce(function () {
-      mouseCursor.components.raycaster.refreshObjects();
-    }, 250)
-  );
 
   mouseCursor.addEventListener('click', handleClick);
   mouseCursor.addEventListener('mouseenter', onMouseEnter);


### PR DESCRIPTION
Remove child-attached listener that refreshes raycaster objects.
I really don't see why this code is there. It was introduced in 63e2e1a22a2d90cfc93d62c1d9ffd26c8778f657 
Around that time https://github.com/aframevr/aframe/commit/a463d6413f9ab20d126b0a70b2ae2be2645330a9 changed raycaster component  where events were changed from loaded/child-attached/child-detached to object3dset/object3dremove
It doesn't make sense to me to have here child-attached listener but not child-detached.
Removing the listener doesn't change anything, all is still working properly as far as I can see.
I guess it was related to 'a-scene :not([data-aframe-inspector])' selector that was probably not working on all browsers at that time?

And because raycaster component is a dependency of cursor, it's better to set raycaster first and then cursor.

