### PR TITLE
Fix TextureWidget componentDidUpdate to not crash React UI on aframe 1.6.0

### DIFF
--- a/src/components/widgets/TextureWidget.js
+++ b/src/components/widgets/TextureWidget.js
@@ -88,17 +88,11 @@ export default class TextureWidget extends React.Component {
     this.setValue(this.props.value || '');
   }
 
-  componentDidUpdate() {
-    var component = this.props.entity.components[this.props.componentname];
-    if (!component) {
-      return;
-    }
-    // component.attrValue may be undefined if component is from a mixin
-    var newValue = component.attrValue && component.attrValue[this.props.name];
-
-    // This will be triggered typically when the element is changed directly with element.setAttribute
-    if (newValue && newValue !== this.state.value) {
-      this.setValue(newValue);
+  componentDidUpdate(prevProps) {
+    // This will be triggered typically when the element is changed directly with
+    // element.setAttribute.
+    if (!Object.is(this.props.value, prevProps.value)) {
+      this.setValue(this.props.value);
     }
   }
 


### PR DESCRIPTION
This closes #722