### PR TITLE
Remove extra space when we use search in left panel

### DIFF
--- a/src/style/scenegraph.styl
+++ b/src/style/scenegraph.styl
@@ -109,7 +109,7 @@
       text-indent 10px
       width 216px
 
-    svg
+    >svg, a.button
       position absolute
       right 14px
       top 10px


### PR DESCRIPTION
That was a minor regression when I did #706

![image](https://github.com/aframevr/aframe-inspector/assets/112249/e86f5efb-b728-4afd-984c-6b1994ae676b)

Before
![image](https://github.com/aframevr/aframe-inspector/assets/112249/02d9fd7c-3b58-4947-b3ca-2c11a32c8613)

After
![image](https://github.com/aframevr/aframe-inspector/assets/112249/899fa202-1629-4feb-9cdd-1908e7e0d8c2)
