### PR TITLE
Fix blue hover on all icon buttons

### DIFF
--- a/src/style/components.styl
+++ b/src/style/components.styl
@@ -237,8 +237,3 @@ a.help-linkhover
 
 #componentEntityHeader .gltfIcon img
   top 0
-
-svg
-  color $white
-  &:hover
-    color $primary

--- a/src/style/index.styl
+++ b/src/style/index.styl
@@ -206,8 +206,8 @@ body.aframe-inspector-opened
     margin-left 10px
     text-decoration none
 
-  a.buttonhover
-    color #1faaf2
+    &:hover
+      color $primary
 
   @keyframes animateopacity
     from { opacity: 0 }

--- a/src/style/scenegraph.styl
+++ b/src/style/scenegraph.styl
@@ -72,6 +72,7 @@
   svg
     color #CCC
 
+  .toolbarActions svg:hover,
   .entityActions svg:hover
     color $primary
 

--- a/src/style/textureModal.styl
+++ b/src/style/textureModal.styl
@@ -36,8 +36,8 @@
   font-size 28px
   font-weight bold
 
-.closehover,
-.closefocus
+.close:hover,
+.close:focus
   color #08f
   cursor pointer
   text-decoration none
@@ -135,7 +135,7 @@
   margin 0 10px 0 0
   padding 5px 10px
 
-.modal buttonfocus
+.modal button:focus
   outline none
 
 .modal button
@@ -143,17 +143,17 @@
   border none
   color #fff
 
-.modal buttonhover,
+.modal button:hover,
 .modal button.hover
   background-color #346392
   text-shadow -1px 1px #27496d
 
-.modal buttonactive,
+.modal button:active,
 .modal button.active
   background-color #27496d
   text-shadow -1px 1px #193047
 
-.modal buttondisabled
+.modal button:disabled
   background-color #888
   cursor none
 


### PR DESCRIPTION
Remove blue on hover on the icon in entity representation in right panel
Add blue hover on toolbarActions icons (plus, play, save)
Fix button css rules for modal to properly style the close button