### PR TITLE
Make ctrl+x/c/v/s work on linux and macOS

### DIFF
--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -130,7 +130,7 @@ export const Shortcuts = {
     }
 
     if (
-      (event.ctrlKey && os === 'windows') ||
+      (event.ctrlKey && os !== 'macos') ||
       (event.metaKey && os === 'macos')
     ) {
       if (

--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -9,9 +9,6 @@ import { getOS } from './utils';
 const os = getOS();
 
 function shouldCaptureKeyEvent(event) {
-  if (event.metaKey) {
-    return false;
-  }
   return (
     event.target.closest('#cameraToolbar') ||
     (event.target.tagName !== 'INPUT' && event.target.tagName !== 'TEXTAREA')


### PR DESCRIPTION
We also use ctrl key on Ubuntu, not just Windows ;)

Those are the shortcuts to cut, copy, paste an entity and focus the search input.