### PR TITLE
[cleanup] Properly remove prop for multi-prop component when value is null or undefined

### DIFF
--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -18,9 +18,7 @@ export function updateEntity(entity, propertyName, value) {
 
     if (value === null || value === undefined) {
       // Remove property.
-      var parameters = entity.getAttribute(splitName[0]);
-      delete parameters[splitName[1]];
-      entity.setAttribute(splitName[0], parameters);
+      entity.removeAttribute(splitName[0], splitName[1]);
     } else {
       // Set property.
       entity.setAttribute(splitName[0], splitName[1], value);


### PR DESCRIPTION
In updateEntity function used on the onChange callback for all widgets,
properly remove prop for multi-prop component when value is null or undefined, the previous code didn't do anything.
Currently none of the widgets onChange seems to go in that branch but this should still be fixed.