### PR TITLE
[feature] Add help button on the right of toolbar actions to show shortcuts modal

### DIFF
--- a/src/components/scenegraph/Toolbar.js
+++ b/src/components/scenegraph/Toolbar.js
@@ -3,7 +3,8 @@ import {
   faPlus,
   faPause,
   faPlay,
-  faFloppyDisk
+  faFloppyDisk,
+  faQuestion
 } from '@fortawesome/free-solid-svg-icons';
 import { AwesomeIcon } from '../AwesomeIcon';
 import Events from '../../lib/Events';
@@ -100,6 +101,10 @@ export default class Toolbar extends React.Component {
     this.setState({ isPlaying: true });
   };
 
+  openHelpModal = () => {
+    Events.emit('openhelpmodal');
+  };
+
   render() {
     const watcherTitle = 'Write changes with aframe-watcher.';
 
@@ -139,6 +144,11 @@ export default class Toolbar extends React.Component {
           >
             <AwesomeIcon icon={faFloppyDisk} />
           </a>
+          <div className="helpButtonContainer">
+            <a className="button" title="Help" onClick={this.openHelpModal}>
+              <AwesomeIcon icon={faQuestion} />
+            </a>
+          </div>
         </div>
       </div>
     );

--- a/src/style/scenegraph.styl
+++ b/src/style/scenegraph.styl
@@ -5,10 +5,17 @@
 
   .toolbarActions
     padding 0 0 5px
+    display flex
+    align-items baseline
 
     a.disabled
       color #666
       cursor default
+
+    .helpButtonContainer
+      flex-grow 1
+      padding-right 10px
+      text-align right
 
 #scenegraph
   background $bg


### PR DESCRIPTION
The h shortcut to show the shortcuts modal is not known by many. Although this is specified in the documentation here
https://aframe.io/docs/master/introduction/visual-inspector-and-dev-tools.html#shortcuts not a lot of persons read the full documentation, or if one reads it, they probably won't remember that this shortcut exists. I actually discovered the feature several years later of developing with aframe when I started updating aframe inspector code.
To make it more discoverable, I propose to add a help button on the right of toolbar actions to show the shortcuts modal.
See the screenshot:
![image](https://github.com/aframevr/aframe-inspector/assets/112249/8ada27f9-336b-4947-a27b-4a2b1a604928)
