### PR TITLE
[bugfix] Update selection box on entityupdate only if it's the selected entity

### DIFF
--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -96,7 +96,11 @@ export function Viewport(inspector) {
   sceneHelpers.add(transformControls);
 
   Events.on('entityupdate', (detail) => {
-    if (inspector.selectedEntity.object3DMap.mesh) {
+    const object = detail.entity.object3D;
+    if (
+      inspector.selected === object &&
+      inspector.selectedEntity.object3DMap.mesh
+    ) {
       selectionBox.setFromObject(inspector.selected);
     }
   });


### PR DESCRIPTION
This fixes an error when using undo with unselected entity so when inspector.selectedEntity can be undefined.