### PR TITLE
[bugfix] Don't select entity on raycaster click if we used one of the controls

### DIFF
--- a/src/lib/raycaster.js
+++ b/src/lib/raycaster.js
@@ -73,11 +73,9 @@ export function initRaycaster(inspector) {
 
   function handleClick(evt) {
     // Check to make sure not dragging.
-    const DRAG_THRESHOLD = 0.03;
-    if (onDownPosition.distanceTo(onUpPosition) >= DRAG_THRESHOLD) {
-      return;
+    if (onDownPosition.distanceTo(onUpPosition) === 0) {
+      inspector.selectEntity(evt.detail.intersectedEl);
     }
-    inspector.selectEntity(evt.detail.intersectedEl);
   }
 
   function onMouseDown(event) {


### PR DESCRIPTION
Don't select entity on raycaster click if we used EditorControls or TransformControls, so actually if we moved the mouse at all.
That's exactly the same condition as in the three.js editor where this works correctly.
https://github.com/mrdoob/three.js/blob/1845f6cd0525b5c73b9da33c40e198c360af29f1/editor/js/Viewport.js#L194

See https://github.com/3DStreet/3dstreet/issues/645 for more details on the issue.