### PR TITLE
[feature] Add a camerachanged event you can use with pathtracer

### DIFF
--- a/src/lib/EditorControls.js
+++ b/src/lib/EditorControls.js
@@ -1,5 +1,3 @@
-import debounce from 'lodash.debounce';
-
 /**
  * @author qiao / https://github.com/qiao
  * @author mrdoob / http://mrdoob.com
@@ -55,10 +53,6 @@ THREE.EditorControls = function (_object, domElement) {
 
   var changeEvent = { type: 'change' };
 
-  this.dispatchChange = debounce(() => {
-    scope.dispatchEvent(changeEvent);
-  }, 100);
-
   this.focus = function (target) {
     var distance;
 
@@ -96,7 +90,7 @@ THREE.EditorControls = function (_object, domElement) {
     object.position.add(delta);
     center.add(delta);
 
-    scope.dispatchChange();
+    scope.dispatchEvent(changeEvent);
   };
 
   var ratio = 1;
@@ -132,7 +126,7 @@ THREE.EditorControls = function (_object, domElement) {
       object.position.add(delta);
     }
 
-    scope.dispatchChange();
+    scope.dispatchEvent(changeEvent);
   };
 
   this.rotate = function (delta) {
@@ -155,7 +149,7 @@ THREE.EditorControls = function (_object, domElement) {
 
     object.lookAt(center);
 
-    scope.dispatchChange();
+    scope.dispatchEvent(changeEvent);
   };
 
   // mouse

--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -107,6 +107,9 @@ export function Viewport(inspector) {
   controls.rotationSpeed = 0.0035;
   controls.zoomSpeed = 0.05;
   controls.setAspectRatio(sceneEl.canvas.width / sceneEl.canvas.height);
+  controls.addEventListener('change', () => {
+    Events.emit('camerachanged');
+  });
 
   Events.on('cameratoggle', (data) => {
     controls.setCamera(data.camera);


### PR DESCRIPTION
Remove EditorControls debounce on `change` event and add a `camerachanged` event that you can use with [pathtracer](https://github.com/gkjohnson/three-gpu-pathtracer)
This is similar to three.js editor https://github.com/mrdoob/three.js/blob/8a102ea21d19adfd8214e20a347d80f49e098d8c/editor/js/Viewport.js#L280