### PR TITLE
[bugfix] Dispose helper when removing it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,7 @@ Inspector.prototype = {
       let helper;
 
       if (object instanceof THREE.Camera) {
-        this.cameraHelper = helper = new THREE.CameraHelper(object, 0.1);
+        this.cameraHelper = helper = new THREE.CameraHelper(object);
       } else if (object instanceof THREE.PointLight) {
         helper = new THREE.PointLightHelper(object, 1);
       } else if (object instanceof THREE.DirectionalLight) {

--- a/src/index.js
+++ b/src/index.js
@@ -136,6 +136,7 @@ Inspector.prototype = {
       const helper = this.helpers[node.uuid];
       if (helper) {
         this.sceneHelpers.remove(helper);
+        helper.dispose();
         delete this.helpers[node.uuid];
         Events.emit('helperremove', this.helpers[node.uuid]);
       }


### PR DESCRIPTION
Dispose helper when removing it to properly dispose material and geometry.
In recent three.js version all helpers have now a dispose function, that was not the case historically.
This is similar to three.js editor
https://github.com/mrdoob/three.js/blob/267e76c2d884cb0b4c12f4c5ffa5a7d03ce82bba/editor/js/Editor.js#L472

Also remove the second argument to CameraHelper, CameraHelper only takes one argument.
https://github.com/mrdoob/three.js/blob/267e76c2d884cb0b4c12f4c5ffa5a7d03ce82bba/src/helpers/CameraHelper.js#L21