### PR TITLE
[cleanup] Remove unused onDoubleClickPosition

### DIFF
--- a/src/lib/raycaster.js
+++ b/src/lib/raycaster.js
@@ -55,7 +55,6 @@ export function initRaycaster(inspector) {
 
   const onDownPosition = new THREE.Vector2();
   const onUpPosition = new THREE.Vector2();
-  const onDoubleClickPosition = new THREE.Vector2();
 
   function onMouseEnter() {
     Events.emit(
@@ -110,12 +109,6 @@ export function initRaycaster(inspector) {
    * Focus on double click.
    */
   function onDoubleClick(event) {
-    const array = getMousePosition(
-      inspector.container,
-      event.clientX,
-      event.clientY
-    );
-    onDoubleClickPosition.fromArray(array);
     const intersectedEl = mouseCursor.components.cursor.intersectedEl;
     if (!intersectedEl) {
       return;


### PR DESCRIPTION
In three.js editor, this is used https://github.com/mrdoob/three.js/blob/267e76c2d884cb0b4c12f4c5ffa5a7d03ce82bba/editor/js/Viewport.js#L255-L258
but here we don't use it, we use aframe cursor component instead.