### PR TITLE
[bugfix] Update camera aspect ratio on window resize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,6 @@ Inspector.prototype = {
     this.inspectorActive = false;
 
     this.viewport = new Viewport(this);
-    Events.emit('windowresize');
 
     this.sceneEl.object3D.traverse((node) => {
       this.addHelper(node);

--- a/src/lib/cameras.js
+++ b/src/lib/cameras.js
@@ -118,5 +118,4 @@ function setOrthoCamera(camera, dir, ratio) {
   camera.bottom = info.bottom || -10;
   camera.position.copy(info.position);
   camera.rotation.copy(info.rotation);
-  camera.updateProjectionMatrix();
 }


### PR DESCRIPTION
Updating the aspect ratio of the editor camera worked only for the active perspective camera, it didn't work when when you were using orthographic camera, and also the case using ortho, resize and then switching back to perspective camera didn't work either. This PR fixes updating the camera aspect in all cases.

For more details on the issue, this was discussed in https://github.com/3DStreet/3dstreet/issues/635