### PR TITLE
[bugfix] Only update selectionBox if the model-loaded event came from the entity

### DIFF
--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -162,14 +162,13 @@ export function Viewport(inspector) {
         selectionBox.setFromObject(object);
         selectionBox.visible = true;
       } else if (object.el.hasAttribute('gltf-model')) {
-        object.el.addEventListener(
-          'model-loaded',
-          () => {
-            selectionBox.setFromObject(object);
-            selectionBox.visible = true;
-          },
-          { once: true }
-        );
+        const listener = (event) => {
+          if (event.target !== object.el) return; // we got an event for a child, ignore
+          selectionBox.setFromObject(object);
+          selectionBox.visible = true;
+          object.el.removeEventListener('model-loaded', listener);
+        };
+        object.el.addEventListener('model-loaded', listener);
       }
 
       transformControls.attach(object);


### PR DESCRIPTION
Only update selectionBox if the model-loaded event came from the entity and not from a child.
This is a more robust version of what I implemented in #711

I had an issue with a modified version of createEntity that also support creating children with gltf-model.
Before:
![Capture d’écran du 2024-08-06 19-19-42](https://github.com/user-attachments/assets/6aadb876-2e4f-4402-aa9e-dc5ae72af573)
After:
![Capture d’écran du 2024-08-06 19-20-21](https://github.com/user-attachments/assets/c4cc56eb-3589-42c7-b125-931666bbc02a)
