### PR TITLE
[bugfix] Fix React UI crash selecting a-scene in scene graph

### DIFF
--- a/src/components/components/PropertyRow.js
+++ b/src/components/components/PropertyRow.js
@@ -49,7 +49,7 @@ export default class PropertyRow extends React.Component {
 
     const value =
       props.schema.type === 'selector'
-        ? props.entity.getDOMAttribute(props.componentname)[props.name]
+        ? props.entity.getDOMAttribute(props.componentname)?.[props.name]
         : props.data;
 
     const widgetProps = {
@@ -114,7 +114,7 @@ export default class PropertyRow extends React.Component {
     const props = this.props;
     const value =
       props.schema.type === 'selector'
-        ? props.entity.getDOMAttribute(props.componentname)[props.name]
+        ? props.entity.getDOMAttribute(props.componentname)?.[props.name]
         : JSON.stringify(props.data);
     const title =
       props.name + '\n - type: ' + props.schema.type + '\n - value: ' + value;


### PR DESCRIPTION
Check for `undefined` via the optional chaining `?.` operator before accessing the property now that `getDOMAttribute` may return `undefined` in aframe 1.6.0 instead of `{}` we always had previously.

This fixes #741