### PR TITLE
[bugfix] Check also for curr not null in the while loop

### DIFF
--- a/src/components/scenegraph/SceneGraph.js
+++ b/src/components/scenegraph/SceneGraph.js
@@ -186,7 +186,7 @@ export default class SceneGraph extends React.Component {
     if (!curr) {
       return false;
     }
-    while (curr !== undefined && curr.isEntity) {
+    while (curr?.isEntity) {
       if (!this.isExpanded(curr)) {
         return false;
       }


### PR DESCRIPTION
Use the ?. operator here to check for undefined or null before accessing isEntity. We got an error at this place one time on 3dstreet because parentNode was null. Note that it makes more sense to check for null here because parentNode can returns null, never undefined normally.