### PR TITLE
[bugfix] Remove debounce of rebuildEntityOptions in SceneGraph to fix expand issue to created element

### DIFF
--- a/src/components/scenegraph/SceneGraph.js
+++ b/src/components/scenegraph/SceneGraph.js
@@ -34,13 +34,9 @@ export default class SceneGraph extends React.Component {
       selectedIndex: -1
     };
 
-    this.rebuildEntityOptions = debounce(
-      this.rebuildEntityOptions.bind(this),
-      1000
-    );
     this.updateFilteredEntities = debounce(
       this.updateFilteredEntities.bind(this),
-      500
+      100
     );
   }
 


### PR DESCRIPTION
Remove debounce of rebuildEntityOptions. It is not needed and it added 1s of delay of refreshing the UI when changing a mixin or creating a new element. This fixes expanding the tree to a created element as a child of another collapsed element.  (when done programmatically, there is no ui or shortcut to do that currently in aframe inspector)
Reduce updateFilteredEntities debounce from 500ms to 100ms so the filter is quicker.

The rebuildEntityOptions debounce may have been needed in the past for some reason, but in the current code the only time rebuildEntityOptions is called is on the following events that are seldom emitted
https://github.com/aframevr/aframe-inspector/blob/31f744f41f6773b4d90d19907d260e9b1ad0a444/src/components/scenegraph/SceneGraph.js#L49-L55