### PR TITLE
[feature] Scroll to selected entity

### DIFF
--- a/src/components/scenegraph/Entity.js
+++ b/src/components/scenegraph/Entity.js
@@ -17,6 +17,7 @@ import Events from '../../lib/Events';
 
 export default class Entity extends React.Component {
   static propTypes = {
+    id: PropTypes.string,
     depth: PropTypes.number,
     entity: PropTypes.object,
     isExpanded: PropTypes.bool,
@@ -114,7 +115,7 @@ export default class Entity extends React.Component {
     });
 
     return (
-      <div className={className} onClick={this.onClick}>
+      <div className={className} onClick={this.onClick} id={this.props.id}>
         <span>
           {visibilityButton}
           <span

--- a/src/components/scenegraph/SceneGraph.js
+++ b/src/components/scenegraph/SceneGraph.js
@@ -71,7 +71,11 @@ export default class SceneGraph extends React.Component {
     for (let i = 0; i < this.state.filteredEntities.length; i++) {
       const entityOption = this.state.filteredEntities[i];
       if (entityOption.entity === entity) {
-        this.setState({ selectedIndex: i });
+        this.setState({ selectedIndex: i }, () => {
+          document
+            .getElementById('sgnode' + i)
+            ?.scrollIntoView({ behavior: 'smooth' });
+        });
         // Make sure selected value is visible in scenegraph
         this.expandToRoot(entity);
         Events.emit('entityselect', entity);
@@ -105,7 +109,11 @@ export default class SceneGraph extends React.Component {
           continue;
         }
 
-        entities.push({ entity: entity, depth: depth });
+        entities.push({
+          entity: entity,
+          depth: depth,
+          id: 'sgnode' + entities.length
+        });
 
         treeIterate(entity, depth);
       }


### PR DESCRIPTION
When selecting an entity in viewport or creating new entity with n shortcut, scroll to the selected entity in scene graph.
[scroll-to-selected-entity.webm](https://github.com/user-attachments/assets/253d12ed-6c6f-489a-80bd-785845c07e09)

I'm not sure that's a good behavior for everyone.
Blender for example doesn't have that behavior.
vscode has that behavior when switching tabs, but it doesn't scroll unnecessarily if the other file is already visible in the files explorer. If it isn't visible, it scrolls and the file is in the middle of the files explorer. That may be better.