### PR TITLE
[cleanup] Remove unused m shortcut that was used in the removed motion capture feature

### DIFF
--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -65,11 +65,6 @@ export const Shortcuts = {
       Events.emit('togglegrid');
     }
 
-    // m: motion capture
-    if (keyCode === 77) {
-      Events.emit('togglemotioncapture');
-    }
-
     // n: new entity
     if (keyCode === 78) {
       Events.emit('entitycreate', { element: 'a-entity', components: {} });


### PR DESCRIPTION
This should have been removed when the feature was removed in https://github.com/aframevr/aframe-inspector/commit/40730d146b873b205b85957bfd02179a12a2b8da