### PR TITLE
[cleanup] Remove redundant removeObject call, this is already called on child-detached

### DIFF
--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -57,7 +57,6 @@ export function removeEntity(entity, force) {
       )
     ) {
       var closest = findClosestEntity(entity);
-      AFRAME.INSPECTOR.removeObject(entity.object3D);
       entity.parentNode.removeChild(entity);
       AFRAME.INSPECTOR.selectEntity(closest);
     }


### PR DESCRIPTION
Remove redundant removeObject call that removes helpers, this is already called on child-detached event.
This was called a second time when removeChild was called because of the listener here
https://github.com/aframevr/aframe-inspector/blob/05d895e62f9319b1479491026888647e4d146f21/src/index.js#L201-L204