### PR TITLE
[bugfix] Properly bind the exposed on/off/emit functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,9 @@ function Inspector() {
   this.history = require('./lib/history');
   this.isFirstOpen = true;
   this.modules = {};
-  this.on = Events.on;
-  this.emit = Events.emit;
-  this.off = Events.off;
+  this.on = Events.on.bind(Events);
+  this.emit = Events.emit.bind(Events);
+  this.off = Events.off.bind(Events);
   this.opened = false;
 
   // Wait for stuff.


### PR DESCRIPTION
Be sure the exposed `on`/`off`/`emit` on `Inspector` are bound to `Events` so an event emitted with `AFRAME.INSPECTOR.emit` is correctly catched in an `Events.on` listener, otherwise it's using two different registries and doesn't work.

And example of usage of emit externally for a component to trigger the update of the scene graph.
https://github.com/3DStreet/3dstreet/pull/789/commits/69904017a9557f80e0881f8bb641fd655c50d28e