### PR TITLE
[cleanup] Remove exposed on/emit/off that were not working properly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,6 @@ function Inspector() {
   this.history = require('./lib/history');
   this.isFirstOpen = true;
   this.modules = {};
-  this.on = Events.on;
-  this.emit = Events.emit;
-  this.off = Events.off;
   this.opened = false;
 
   // Wait for stuff.


### PR DESCRIPTION
Remove exposed on/emit/off that were not working properly because of bad binding (see #754 for an explanation) so not used in the wild.
The `this.on` was there a long time ago, we introduced the `this.off` and `this.emit` in #719 but those weren't working.
@gregogalante you can still do your own build with #754 changes if you need that.

Instead of exposing the events publicly, let's keep it internal for now.
I want later to define documented commands that can be used instead (undo compatible).

