### PR TITLE
[bugfix] Disable focusing an object with orthographic camera

### DIFF
--- a/src/lib/EditorControls.js
+++ b/src/lib/EditorControls.js
@@ -54,6 +54,9 @@ THREE.EditorControls = function (_object, domElement) {
   var changeEvent = { type: 'change' };
 
   this.focus = function (target) {
+    if (this.isOrthographic) {
+      return;
+    }
     var distance;
 
     box.setFromObject(target);


### PR DESCRIPTION
Disable focusing an object with orthographic camera (used in top, left, right views) that put the camera at a wrong angle and in an unrecoverable state.