### PR TITLE
Remove buggy ctrl+x to cut entity to paste it right away

### DIFF
--- a/src/components/modals/ModalHelp.js
+++ b/src/components/modals/ModalHelp.js
@@ -54,7 +54,7 @@ export default class ModalHelp extends React.Component {
         { key: ['ctrl | cmd', 'c'], description: 'Copy selected entity' },
         { key: ['ctrl | cmd', 'v'], description: 'Paste entity' },
         { key: ['h'], description: 'Show this help' },
-        { key: ['Esc'], description: 'Unselect entity' },
+        { key: ['esc'], description: 'Unselect entity' },
         { key: ['ctrl', 'alt', 'i'], description: 'Switch Edit and VR Modes' }
       ]
     ];

--- a/src/components/modals/ModalHelp.js
+++ b/src/components/modals/ModalHelp.js
@@ -39,7 +39,7 @@ export default class ModalHelp extends React.Component {
         { key: ['g'], description: 'Toggle grid visibility' },
         { key: ['n'], description: 'Add new entity' },
         { key: ['o'], description: 'Toggle local between global transform' },
-        { key: ['supr | backspace'], description: 'Delete selected entity' }
+        { key: ['supr | backspace'], description: 'Delete selected entity' }
       ],
       [
         { key: ['0'], description: 'Toggle panels' },
@@ -51,8 +51,8 @@ export default class ModalHelp extends React.Component {
         { key: ['6'], description: 'Back view' },
         { key: ['7'], description: 'Front view' },
 
-        { key: ['ctrl | cmd', 'c'], description: 'Copy selected entity' },
-        { key: ['ctrl | cmd', 'v'], description: 'Paste entity' },
+        { key: ['ctrl | cmd', 'c'], description: 'Copy selected entity' },
+        { key: ['ctrl | cmd', 'v'], description: 'Paste entity' },
         { key: ['h'], description: 'Show this help' },
         { key: ['Esc'], description: 'Unselect entity' },
         { key: ['ctrl', 'alt', 'i'], description: 'Switch Edit and VR Modes' }

--- a/src/components/modals/ModalHelp.js
+++ b/src/components/modals/ModalHelp.js
@@ -51,7 +51,6 @@ export default class ModalHelp extends React.Component {
         { key: ['6'], description: 'Back view' },
         { key: ['7'], description: 'Front view' },
 
-        { key: ['ctrl | cmd', 'x'], description: 'Cut selected entity' },
         { key: ['ctrl | cmd', 'c'], description: 'Copy selected entity' },
         { key: ['ctrl | cmd', 'v'], description: 'Paste entity' },
         { key: ['h'], description: 'Show this help' },

--- a/src/components/modals/ModalHelp.js
+++ b/src/components/modals/ModalHelp.js
@@ -39,7 +39,7 @@ export default class ModalHelp extends React.Component {
         { key: ['g'], description: 'Toggle grid visibility' },
         { key: ['n'], description: 'Add new entity' },
         { key: ['o'], description: 'Toggle local between global transform' },
-        { key: ['supr | backspace'], description: 'Delete selected entity' }
+        { key: ['delete | backspace'], description: 'Delete selected entity' }
       ],
       [
         { key: ['0'], description: 'Toggle panels' },

--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -129,12 +129,6 @@ export const Shortcuts = {
         AFRAME.INSPECTOR.selectedEntity &&
         document.activeElement.tagName !== 'INPUT'
       ) {
-        // x: cut selected entity
-        if (event.keyCode === 88) {
-          AFRAME.INSPECTOR.entityToCopy = AFRAME.INSPECTOR.selectedEntity;
-          removeSelectedEntity(true);
-        }
-
         // c: copy selected entity
         if (event.keyCode === 67) {
           AFRAME.INSPECTOR.entityToCopy = AFRAME.INSPECTOR.selectedEntity;

--- a/src/lib/shortcuts.js
+++ b/src/lib/shortcuts.js
@@ -33,7 +33,7 @@ export const Shortcuts = {
       Events.emit('openhelpmodal');
     }
 
-    // esc: close inspector
+    // esc: unselect entity
     if (keyCode === 27) {
       if (this.inspector.selectedEntity) {
         this.inspector.selectEntity(null);
@@ -70,7 +70,7 @@ export const Shortcuts = {
       Events.emit('entitycreate', { element: 'a-entity', components: {} });
     }
 
-    // backspace & supr: remove selected entity
+    // backspace & delete: remove selected entity
     if (keyCode === 8 || keyCode === 46) {
       removeSelectedEntity();
     }
@@ -148,7 +148,7 @@ export const Shortcuts = {
       }
     }
 
-    // º: toggle sidebars visibility
+    // 0: toggle sidebars visibility
     if (event.keyCode === 48) {
       Events.emit('togglesidebar', { which: 'all' });
       event.preventDefault();


### PR DESCRIPTION
Remove buggy ctrl+x to cut entity to paste it right away, because the entity is removed from the DOM, some components like position/rotation/scale reset to their default value.
If we really want to fix it, we should really keep an object representation of the deleted entity so that it could use createEntity(definition) when we press ctrl+v in this case instead of cloneEntity, but we currently don't support creating children on createEntity.
To be honest, I don't think it's worth to keep that feature, and I really don't understand what was the purpose of it in the first place.
We could keep it as way to remove an entity without confirmation, in this case we remove the `AFRAME.INSPECTOR.entityToCopy` assigment here and we reflect that purpose in the help modal. Thoughts?

Note that the ctrl+x,c,v shortcuts only worked on Windows since a long time, and were fixed for Linux and macOS only recently #729

