### PR TITLE
[bugfix] Better camera placement when focusing an element

### DIFF
--- a/src/lib/EditorControls.js
+++ b/src/lib/EditorControls.js
@@ -69,9 +69,13 @@ THREE.EditorControls = function (_object, domElement) {
     }
 
     object.position.copy(
-      target.localToWorld(new THREE.Vector3(0, 0, distance * 2))
+      target.localToWorld(
+        new THREE.Vector3(0, center.y + distance * 0.5, distance * 2.5)
+      )
     );
-    object.lookAt(target.getWorldPosition(new THREE.Vector3()));
+    const pos = target.getWorldPosition(new THREE.Vector3());
+    pos.y = center.y;
+    object.lookAt(pos);
 
     scope.dispatchEvent(changeEvent);
   };


### PR DESCRIPTION
The previous code worked okay on geometry primitives because their position and bounding box center are the same. But for a model, that's not the case, the camera was on the ground, that was not super useful, so you ended up always moving the camera up and scrolling back a bit.
So now the camera is looking straight at the center of the bounding box and a bit higher by a quarter of the bounding box.
See the issue we had https://github.com/3DStreet/3dstreet/issues/798
and now after the change https://x.com/3dstreetapp/status/1829746759603798145