### PR TITLE
[bugfix] Update transform controls scale on camera change

### DIFF
--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -112,6 +112,7 @@ export function Viewport(inspector) {
   controls.zoomSpeed = 0.05;
   controls.setAspectRatio(sceneEl.canvas.width / sceneEl.canvas.height);
   controls.addEventListener('change', () => {
+    transformControls.update(true); // true is updateScale
     Events.emit('camerachanged');
   });
 
@@ -177,7 +178,6 @@ export function Viewport(inspector) {
 
   Events.on('objectfocus', (object) => {
     controls.focus(object);
-    transformControls.update();
   });
 
   Events.on('geometrychanged', (object) => {


### PR DESCRIPTION
The scale of transform controls is now updated when you focus an element, zoom in, zoom out. This closes #649