### PR TITLE
Update to GLTFExporter from three r168 which has better performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-select": "^5.8.0",
-        "three": "0.161.0"
+        "three": "0.168.0"
       },
       "devDependencies": {
         "@babel/core": "^7.24.0",
@@ -14386,9 +14386,10 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.161.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.161.0.tgz",
-      "integrity": "sha512-LC28VFtjbOyEu5b93K0bNRLw1rQlMJ85lilKsYj6dgTu+7i17W+JCCEbvrpmNHF1F3NAUqDSWq50UD7w9H2xQw=="
+      "version": "0.168.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.168.0.tgz",
+      "integrity": "sha512-6m6jXtDwMJEK/GGMbAOTSAmxNdzKvvBzgd7q8bE/7Tr6m7PaBh5kKLrN7faWtlglXbzj7sVba48Idwx+NRsZXw==",
+      "license": "MIT"
     },
     "node_modules/through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-select": "^5.8.0",
-    "three": "0.161.0"
+    "three": "0.168.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",


### PR DESCRIPTION
This GLTFExporter change in r167 https://github.com/mrdoob/three.js/pull/28893 speed up one of my glb export from 7s to 3s. If you're using a canvas to create an image to download, you should really set { willReadFrequently: true } when getting the 2d context.