### PR TITLE
Don't export position/rotation/scale/visible if it's the empty value

### DIFF
--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -205,6 +205,17 @@ function optimizeComponents(copy, source) {
       var value = stringifyComponentValue(schema, optimalUpdate);
       setAttribute.call(copy, name, value);
     }
+
+    // Remove special components if they use the default value
+    if (
+      value === '' &&
+      (name === 'visible' ||
+        name === 'position' ||
+        name === 'rotation' ||
+        name === 'scale')
+    ) {
+      removeAttribute.call(copy, name);
+    }
   });
 }
 


### PR DESCRIPTION
This fixes #763 

For example select the box, initially when you copy the entity to clipboard, you get
```html
<a-box id="box" position="0 0.91 0" height="2" color="#FFC65D"></a-box>
```

Then change the rotation to y 45 and mark it as not visible, if you copy the entity to clipboard:
```html
<a-box id="box" position="0 0.91 0" height="2" color="#FFC65D" visible="false" rotation="0 45 0"></a-box>
```

Then toggle back visible and reset rotation to 0.
Before the PR:
```html
<a-box id="box" position="0 0.91 0" height="2" color="#FFC65D" visible="" rotation=""></a-box>
```

After the PR:
```html
<a-box id="box" position="0 0.91 0" height="2" color="#FFC65D"></a-box>
```