### PR TITLE
Remove inspector component to properly unregister keydown listener

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -168,6 +168,9 @@ Inspector.prototype = {
   },
 
   initEvents: function () {
+    // Remove inspector component to properly unregister keydown listener when the inspector is loaded via a script tag,
+    // otherwise the listener will be registered twice and we can't toggle the inspector from viewer mode with the shortcut.
+    this.sceneEl.removeAttribute('inspector');
     window.addEventListener('keydown', (evt) => {
       // Alt + Ctrl + i: Shorcut to toggle the inspector
       const shortcutPressed =


### PR DESCRIPTION
Remove inspector component to properly unregister the keydown listener registered in the inspector component when the inspector is loaded via a script tag like here https://github.com/aframevr/aframe-inspector/blob/a9901b962138bcfe9e945fe00b070d9ffc4fcc25/examples/index.html#L64
otherwise the listener will be registered twice and we can't toggle the inspector from viewer mode with the shortcut (it will toggle the inspector and toggle back to viewer mode right away)
When loaded via script tag, removeEventListeners is not executed 
https://github.com/aframevr/aframe/blob/9cdc30465247685a69067eb5beb0d177367eebc9/src/components/scene/inspector.js#L104
removing the component will execute removeEventListeners
https://github.com/aframevr/aframe/blob/9cdc30465247685a69067eb5beb0d177367eebc9/src/components/scene/inspector.js#L57