### PR TITLE
Remove setting data-aframe-inspector-original-camera attribute

### DIFF
--- a/src/lib/cameras.js
+++ b/src/lib/cameras.js
@@ -21,10 +21,6 @@ export function initCameras(inspector) {
   const sceneEl = inspector.sceneEl;
 
   const originalCamera = (inspector.currentCameraEl = sceneEl.camera.el);
-  inspector.currentCameraEl.setAttribute(
-    'data-aframe-inspector-original-camera',
-    ''
-  );
 
   // If the current camera is the default, we should prevent AFRAME from
   // remove it once when we inject the editor's camera.


### PR DESCRIPTION
Remove setting data-aframe-inspector-original-camera attribute that is not used anywhere.
This avoid this attribute to be exported when using copy entity html to clipboard.

@dmarcos 