### PR TITLE
In optimizeComponents be sure to also remove components that are defined in the primitive with empty object

### DIFF
--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -284,6 +284,13 @@ function getImplicitValue(component, source) {
   function _multi() {
     var value;
 
+    // Set isInherited to true if the component is inherited from primitive defaultComponents and is empty object
+    var defaults = source.defaultComponentsFromPrimitive;
+    isInherited =
+      defaults &&
+      /* eslint-disable-next-line no-prototype-builtins */
+      defaults.hasOwnProperty(component.name) &&
+      Object.keys(defaults[component.name]).length === 0;
     Object.keys(component.schema).forEach(function (propertyName) {
       var propertyValue = getFromAttribute(component, propertyName, source);
       if (propertyValue === undefined) {
@@ -362,7 +369,7 @@ function getFromAttribute(component, propertyName, source) {
  */
 function getMixedValue(component, propertyName, source) {
   var value;
-  var reversedMixins = source.mixinEls.reverse();
+  var reversedMixins = source.mixinEls.toReversed();
   for (var i = 0; value === undefined && i < reversedMixins.length; i++) {
     var mixin = reversedMixins[i];
     /* eslint-disable-next-line no-prototype-builtins */
@@ -379,7 +386,7 @@ function getMixedValue(component, propertyName, source) {
 
 /**
  * Gets the value for a component or component's property coming from primitive
- * defaults or a-frame defaults. In this specific order.
+ * defaults.
  *
  * @param {Component} component      Component to be found.
  * @param {string}    [propertyName] If provided, component's property to be
@@ -390,18 +397,13 @@ function getMixedValue(component, propertyName, source) {
  */
 function getInjectedValue(component, propertyName, source) {
   var value;
-  var primitiveDefaults = source.defaultComponentsFromPrimitive || {};
-  var aFrameDefaults = source.defaultComponents || {};
-  var defaultSources = [primitiveDefaults, aFrameDefaults];
-  for (var i = 0; value === undefined && i < defaultSources.length; i++) {
-    var defaults = defaultSources[i];
-    /* eslint-disable-next-line no-prototype-builtins */
-    if (defaults.hasOwnProperty(component.name)) {
-      if (!propertyName) {
-        value = defaults[component.name];
-      } else {
-        value = defaults[component.name][propertyName];
-      }
+  var primitiveDefaults = source.defaultComponentsFromPrimitive;
+  /* eslint-disable-next-line no-prototype-builtins */
+  if (primitiveDefaults && primitiveDefaults.hasOwnProperty(component.name)) {
+    if (!propertyName) {
+      value = primitiveDefaults[component.name];
+    } else {
+      value = primitiveDefaults[component.name][propertyName];
     }
   }
   return value;

--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -289,8 +289,8 @@ function getImplicitValue(component, source) {
     isInherited =
       defaults &&
       /* eslint-disable-next-line no-prototype-builtins */
-      defaults.hasOwnProperty(component.name) &&
-      Object.keys(defaults[component.name]).length === 0;
+      defaults.hasOwnProperty(component.attrName) &&
+      Object.keys(defaults[component.attrName]).length === 0;
     Object.keys(component.schema).forEach(function (propertyName) {
       var propertyValue = getFromAttribute(component, propertyName, source);
       if (propertyValue === undefined) {
@@ -373,11 +373,11 @@ function getMixedValue(component, propertyName, source) {
   for (var i = 0; value === undefined && i < reversedMixins.length; i++) {
     var mixin = reversedMixins[i];
     /* eslint-disable-next-line no-prototype-builtins */
-    if (mixin.attributes.hasOwnProperty(component.name)) {
+    if (mixin.attributes.hasOwnProperty(component.attrName)) {
       if (!propertyName) {
-        value = mixin.getAttribute(component.name);
+        value = mixin.getAttribute(component.attrName);
       } else {
-        value = mixin.getAttribute(component.name)[propertyName];
+        value = mixin.getAttribute(component.attrName)[propertyName];
       }
     }
   }
@@ -398,12 +398,15 @@ function getMixedValue(component, propertyName, source) {
 function getInjectedValue(component, propertyName, source) {
   var value;
   var primitiveDefaults = source.defaultComponentsFromPrimitive;
-  /* eslint-disable-next-line no-prototype-builtins */
-  if (primitiveDefaults && primitiveDefaults.hasOwnProperty(component.name)) {
+  if (
+    primitiveDefaults &&
+    /* eslint-disable-next-line no-prototype-builtins */
+    primitiveDefaults.hasOwnProperty(component.attrName)
+  ) {
     if (!propertyName) {
-      value = primitiveDefaults[component.name];
+      value = primitiveDefaults[component.attrName];
     } else {
-      value = primitiveDefaults[component.name][propertyName];
+      value = primitiveDefaults[component.attrName][propertyName];
     }
   }
   return value;


### PR DESCRIPTION
In optimizeComponents used by the copy entity to clipboard feature, be sure to also remove components that are defined in the primitive with empty object, for example a-camera here https://github.com/aframevr/aframe/blob/a26768db5fe0f04a3b8fec3e73780b1855c3c75c/src/extras/primitives/primitives/a-camera.js#L5-L7

`defaultComponentsFromPrimitive` is defined by `this.defaultComponentsFromPrimitive = definition.defaultComponents || definition.defaultAttributes || {};` in aframe registerPrimitive. https://github.com/aframevr/aframe/blob/a26768db5fe0f04a3b8fec3e73780b1855c3c75c/src/extras/primitives/primitives.js#L37
`defaultComponents` is only on the definition, never on the html element, so checking for `source.defaultComponents` is always undefined from my understanding.
I modified `getInjectedValue` to check only `defaultComponentsFromPrimitive` and don't create unnessary object if it's undefined.

Also in `getMixedValue`, the line `source.mixinEls.reverse()` was reversing the mixinEls in place, so the order changed on each execution, not really what we want here, I replaced by `toReversed()`

`getImplicitValue` didn't return isInherited true in case of empty object in the primitive `defaultComponents`, so the component wasn't deleted as part of the `if (isInherited && doesNotNeedUpdate)` check.
https://github.com/aframevr/aframe-inspector/blob/ebb07fa84fe642a0f4112006c2c67a7b85c5cf85/src/lib/entity.js#L201-L202

I fixed it.

Before:

```html
<a-cursor raycaster cursor></a-cursor>
```

After:
```html
<a-cursor raycaster></a-cursor>
```

`raycaster` is set by the `cursor` component so that's why it still shows up, but I don't mind, it's good practice to define objects property in `raycaster` anyway.
  
Before:
```html
<a-camera camera look-controls wasd-controls>
```

After:
```html
<a-camera>
```