### PR TITLE
Allow editing a custom type like event-set component schema

### DIFF
--- a/src/components/components/PropertyRow.js
+++ b/src/components/components/PropertyRow.js
@@ -103,6 +103,14 @@ export default class PropertyRow extends React.Component {
         return <BooleanWidget {...widgetProps} />;
       }
       default: {
+        if (
+          props.schema.type === 'string' &&
+          widgetProps.value &&
+          typeof widgetProps.value !== 'string'
+        ) {
+          // Allow editing a custom type like event-set component schema
+          widgetProps.value = props.schema.stringify(widgetProps.value);
+        }
         return <InputWidget {...widgetProps} />;
       }
     }


### PR DESCRIPTION
In the http://localhost:3333/examples/controllers.html example, the `event-set__click` component is wrongly serialized to "[object Object]"` in the right panel so we can't edit it.
To edit it properly we need the fix in this PR and in the event-set component there https://github.com/supermedium/superframe/pull/344

@dmarcos 