### PR TITLE
Emit entityselect even if entity is null so the React UI updates properly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,7 @@ Inspector.prototype = {
       this.select(null);
     }
 
-    if (entity && emit === undefined) {
+    if (emit === undefined) {
       Events.emit('entityselect', entity);
     }
 


### PR DESCRIPTION
When you press escape it does `AFRAME.INSPECTOR.selectEntity(null)` but the entityselect event wasn't emitted so the UI didn't update properly, and the right panel stayed open instead of closing.
@dmarcos 