### PR TITLE
In SceneGraph, only scroll node into view if it's not currently visible

### DIFF
--- a/src/components/scenegraph/SceneGraph.js
+++ b/src/components/scenegraph/SceneGraph.js
@@ -73,11 +73,21 @@ export default class SceneGraph extends React.Component {
       if (entityOption.entity === entity) {
         this.setState({ selectedIndex: i });
         setTimeout(() => {
-          // wait 500ms to allow user to double click on entity
-          document
-            .getElementById('sgnode' + i)
-            ?.scrollIntoView({ behavior: 'smooth' });
-        }, 500);
+          // wait 100ms to allow React to update the UI and create the node we're interested in
+          const node = document.getElementById('sgnode' + i);
+          const scrollableContainer = document.querySelector(
+            '#scenegraph .outliner'
+          );
+          if (!node || !scrollableContainer) return;
+          const containerRect = scrollableContainer.getBoundingClientRect();
+          const nodeRect = node.getBoundingClientRect();
+          const isVisible =
+            nodeRect.top >= containerRect.top &&
+            nodeRect.bottom <= containerRect.bottom;
+          if (!isVisible) {
+            node.scrollIntoView({ behavior: 'smooth' });
+          }
+        }, 100);
         // Make sure selected value is visible in scenegraph
         this.expandToRoot(entity);
         Events.emit('entityselect', entity);


### PR DESCRIPTION
This addresses my comment in #749, with usage, I found it disturbing to always move at the top when you select an entity from the scene graph.

Before:
[inspector-before.webm](https://github.com/user-attachments/assets/ff006f08-4106-4fff-b5d2-76196e503506)

After:
[inspector-after.webm](https://github.com/user-attachments/assets/00127c58-4230-4535-9909-da3d68913b78)

Also decrease the 500ms timeout introduced in #771 to just 100ms, the 500ms was high enough for a double click on a node in the scene graph to work before the scroll was triggered, but now we don't scroll for this case. A timeout is still needed for React to create a node of a sub entity when you click on a sub entity in the viewport. This is not shown in the video above, but it's clearly needed on 3dstreet, see videos https://github.com/3DStreet/3dstreet/pull/981
