### PR TITLE
Textures modal: avoid seeing broken image icon when no preview

### DIFF
--- a/src/components/modals/ModalTextures.js
+++ b/src/components/modals/ModalTextures.js
@@ -357,6 +357,7 @@ export default class ModalTextures extends React.Component {
                 width="155px"
                 height="155px"
                 src={preview.src}
+                style={{ visibility: preview.src ? 'visible' : 'hidden' }}
               />
               {this.state.preview.loaded ? (
                 <div className="detail">


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/d129ddd3-b4d6-43d0-9af2-4488707d6f15)


After:
![image](https://github.com/user-attachments/assets/6832ca71-bc19-42e7-ab8b-f1d31f84aed0)
