### PR TITLE
Textures modal: fix scrolling of available images

### DIFF
--- a/src/style/textureModal.styl
+++ b/src/style/textureModal.styl
@@ -60,6 +60,7 @@
   display flex
   flex-wrap wrap
   margin 15px auto 0
+  max-height calc(100vh - 370px)
   overflow auto
   padding 15px 3px 3px
 


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/84b9a028-c642-4e91-8964-7c9f47e004e8)

After:
![image](https://github.com/user-attachments/assets/a18614a6-bbe9-49f5-a76c-1c228ca2b1a7)
![image](https://github.com/user-attachments/assets/11462b2d-3975-438a-ab94-6b324019d091)
