### PR TITLE
Fix pink color on hover for Back to Scene/Inspect Scene button

### DIFF
--- a/src/style/index.styl
+++ b/src/style/index.styl
@@ -108,7 +108,7 @@ body.aframe-inspector-opened
     width 204px
     z-index 999999999
 
-  .toggle-edithover
+  .toggle-edit:hover
     background-color rgb(228, 43, 90)
 
   input


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2ab98c63-a46c-49b5-8ef5-d1c9d7a50354)
and on hover:
![image](https://github.com/user-attachments/assets/a6ebf6a1-00a2-4fd1-91d8-48baf69717d0)
