### PR TITLE
Fix copy component to clipboard

### DIFF
--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -500,35 +500,14 @@ function getUniqueId(baseId) {
 }
 
 export function getComponentClipboardRepresentation(entity, componentName) {
-  /**
-   * Get the list of modified properties
-   * @param  {Element} entity        Entity where the component belongs
-   * @param  {string} componentName Component name
-   * @return {object}               List of modified properties with their value
-   */
-  function getModifiedProperties(entity, componentName) {
-    var data = entity.components[componentName].data;
-    var defaultData = entity.components[componentName].schema;
-    var diff = {};
-    for (var key in data) {
-      // Prevent adding unknown attributes
-      if (!defaultData[key]) {
-        continue;
-      }
-
-      var defaultValue = defaultData[key].default;
-      var currentValue = data[key];
-
-      // Some parameters could be null and '' like mergeTo
-      if ((currentValue || defaultValue) && currentValue !== defaultValue) {
-        diff[key] = data[key];
-      }
-    }
-    return diff;
+  entity.flushToDOM();
+  const data = entity.getDOMAttribute(componentName);
+  if (!data) {
+    return componentName;
   }
 
-  const diff = getModifiedProperties(entity, componentName);
-  const attributes = AFRAME.utils.styleParser.stringify(diff);
+  const schema = entity.components[componentName].schema;
+  const attributes = stringifyComponentValue(schema, data);
   return `${componentName}="${attributes}"`;
 }
 


### PR DESCRIPTION
Fix copy component to clipboard.
This closes #672

Click on the yellow sphere and then click on copy to clipboard for material, we properly get now:
`material="color: #ff0; roughness: 1"`

Same as copy entity to clipboard:
```html
<a-entity id="yellowSphere" geometry="primitive: sphere" material="color: #ff0; roughness: 1" position="-2 2 -2" models-array="models: one, two"></a-entity>
```