### PR TITLE
Show properties of a component only if allowed by schema condition

### DIFF
--- a/src/components/components/Component.js
+++ b/src/components/components/Component.js
@@ -94,6 +94,30 @@ export default class Component extends React.Component {
 
     return Object.keys(componentData.schema)
       .sort()
+      .filter((propertyName) => {
+        if (!componentData.schema[propertyName].if) {
+          return true;
+        }
+        let showProperty = true;
+        for (const [conditionKey, conditionValue] of Object.entries(
+          componentData.schema[propertyName].if
+        )) {
+          if (Array.isArray(conditionValue)) {
+            if (
+              conditionValue.indexOf(componentData.data[conditionKey]) === -1
+            ) {
+              showProperty = false;
+              break;
+            }
+          } else {
+            if (conditionValue !== componentData.data[conditionKey]) {
+              showProperty = false;
+              break;
+            }
+          }
+        }
+        return showProperty;
+      })
       .map((propertyName) => (
         <PropertyRow
           key={propertyName}


### PR DESCRIPTION
Show properties of a component only if allowed by schema condition.
For example for light component:
- only show castShadow checkbox if type is point, spot or directional
- show additional shadow properties when castShadow checked
- show groundColor only if type is hemisphere

This closes #762