### PR TITLE
Be sure to use a valid id for multiple component, remove dead code optionRenderer

### DIFF
--- a/src/style/components.styl
+++ b/src/style/components.styl
@@ -183,11 +183,6 @@ span.subcomponent
       background #161616
       height 35px
       color $primary
-    .option
-      display flex
-      justify-content space-between
-      span
-        color $primary
 
   #addComponentHeader
     font-size 15px


### PR DESCRIPTION
For the add component select, be sure to use a valid id for multiple component.
Also remove dead code optionRenderer that doesn't exist in the react-select version we're using and that custom option render was to add an icon if a component was loaded, they all are! I think it was a thing of the past with angle/aframe registry.