### PR TITLE
Fix initial camera rotation to be looking at center

### DIFF
--- a/src/lib/cameras.js
+++ b/src/lib/cameras.js
@@ -39,7 +39,8 @@ export function initCameras(inspector) {
   perspectiveCamera.far = 10000;
   perspectiveCamera.near = 0.01;
   perspectiveCamera.position.set(0, 1.6, 2);
-  perspectiveCamera.lookAt(new THREE.Vector3(0, 1.6, -1));
+  const center = new THREE.Vector3(0, 1.6, 0); // same as in viewport.js
+  perspectiveCamera.lookAt(center);
   perspectiveCamera.updateMatrixWorld();
   sceneEl.object3D.add(perspectiveCamera);
   sceneEl.camera = perspectiveCamera;


### PR DESCRIPTION
Fix initial camera rotation to be looking at center, same as in EditorControls when you start to rotate.

You don't see a difference in the inspector with the camera position at 0 1.6 2.
But with an initial camera position at 0 15 2 for example, you can see the camera jump when you start to rotate, that's because EditorControls rotate function forces the camera position to be on a sphere around the center that is at 0 1.6 0 defined at
https://github.com/aframevr/aframe-inspector/blob/e2db22ce8bc7cb4b680c00f363ffc5adbd2b6a8e/src/lib/viewport.js#L110