### PR TITLE
Use early return in optimizeComponents and avoid using setAttribute followed by removeAttribute

### DIFF
--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -209,12 +209,11 @@ function optimizeComponents(copy, source) {
     var doesNotNeedUpdate = optimalUpdate === null;
     if (isInherited && doesNotNeedUpdate) {
       removeAttribute.call(copy, name);
-    } else {
-      var schema = component.schema;
-      var value = stringifyComponentValue(schema, optimalUpdate);
-      setAttribute.call(copy, name, value);
+      return;
     }
 
+    var schema = component.schema;
+    var value = stringifyComponentValue(schema, optimalUpdate);
     // Remove special components if they use the default value
     if (
       value === '' &&
@@ -224,7 +223,10 @@ function optimizeComponents(copy, source) {
         name === 'scale')
     ) {
       removeAttribute.call(copy, name);
+      return;
     }
+
+    setAttribute.call(copy, name, value);
   });
 }
 


### PR DESCRIPTION
I got a warning while playing with jsdoc and typescript about the condition value === '' on a not defined variable.
There was no bug here because a var is hoisted so the check was against undefined != '' so that still worked but the logic was not optimal here, also the attribute was set to later be removed.
I rewrote that to use an early return and call the setAttribute at the end after the condition.
