### PR TITLE
Some optimizations in SceneGraph code

### DIFF
--- a/src/components/scenegraph/Entity.js
+++ b/src/components/scenegraph/Entity.js
@@ -33,10 +33,7 @@ export default class Entity extends React.Component {
 
   toggleVisibility = () => {
     const entity = this.props.entity;
-    const visible =
-      entity.tagName.toLowerCase() === 'a-scene'
-        ? entity.object3D.visible
-        : entity.getAttribute('visible');
+    const visible = entity.object3D.visible;
     entity.setAttribute('visible', !visible);
   };
 
@@ -92,10 +89,7 @@ export default class Entity extends React.Component {
     }
 
     // Visibility button.
-    const visible =
-      tagName === 'a-scene'
-        ? entity.object3D.visible
-        : entity.getAttribute('visible');
+    const visible = entity.object3D.visible;
     const visibilityButton = (
       <i title="Toggle entity visibility" onClick={this.toggleVisibility}>
         {visible ? (

--- a/src/components/scenegraph/SceneGraph.js
+++ b/src/components/scenegraph/SceneGraph.js
@@ -344,7 +344,7 @@ function filterEntity(entity, filter) {
   // Check if the ID, tagName, class, selector includes the filter.
   if (
     entity.id.toUpperCase().indexOf(filter.toUpperCase()) !== -1 ||
-    entity.tagName.toUpperCase().indexOf(filter.toUpperCase()) !== -1 ||
+    entity.tagName.indexOf(filter.toUpperCase()) !== -1 ||
     entity.classList.contains(filter) ||
     entity.matches(filter)
   ) {

--- a/src/components/scenegraph/SceneGraph.js
+++ b/src/components/scenegraph/SceneGraph.js
@@ -92,6 +92,7 @@ export default class SceneGraph extends React.Component {
         this.expandToRoot(entity);
         Events.emit('entityselect', entity);
         found = true;
+        break;
       }
     }
 


### PR DESCRIPTION
Break the for loop when entity is found in SceneGraph selectEntity
No need to still iterate over entities and do a comparison if we found the entity.
I found that when converting this React code to Solid via Claude 4, I figured I push that optimization in here as well.

In scenegraph/Entity.js, simplify getting visible property, it's okay to always use `entity.object3D.visible`, not need to check if it's a-scene.