### PR TITLE
Filter out sceneOnly components when selected entity is not a-scene

### DIFF
--- a/src/components/components/AddComponent.js
+++ b/src/components/components/AddComponent.js
@@ -64,7 +64,14 @@ export default class AddComponent extends React.Component {
   getComponentsOptions() {
     const usedComponents = Object.keys(this.props.entity.components);
     return Object.keys(AFRAME.components)
-      .filter(function (componentName) {
+      .filter((componentName) => {
+        if (
+          AFRAME.components[componentName].sceneOnly &&
+          !this.props.entity.isScene
+        ) {
+          return false;
+        }
+
         return (
           AFRAME.components[componentName].multiple ||
           usedComponents.indexOf(componentName) === -1


### PR DESCRIPTION
When on an entity, fog component is not found
![fog_filtered_out](https://github.com/user-attachments/assets/19b2f7e9-d810-4dad-93e4-06f39e33c1a8)

It only show up on a-scene
![fog_found](https://github.com/user-attachments/assets/dc656ad9-41e7-476c-9aa0-b6ba2180a5fd)
