### PR TITLE
Call pause on the created entity

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -194,6 +194,7 @@ Inspector.prototype = {
 
     Events.on('entitycreate', (definition) => {
       createEntity(definition, (entity) => {
+        entity.pause();
         this.selectEntity(entity);
       });
     });


### PR DESCRIPTION
Call `pause()` on the created entity, important when parent is the scene because `play()` has been called because of `scene.isPlaying = true` hack.
We already did it for the clone entity action but not for the create entity action

To reproduce the issue:
- add an entity
- add a geometry component
- add an animation component with `property` object3D.rotation.y and `to` 360.
- the box animate but it shouldn't, we're in pause.