### PR TITLE
Fix wrong camera position calculation when focusing an element

### DIFF
--- a/src/lib/EditorControls.js
+++ b/src/lib/EditorControls.js
@@ -58,27 +58,27 @@ THREE.EditorControls = function (_object, domElement) {
       return;
     }
     var distance;
+    var localCenterY;
 
     box.setFromObject(target);
 
     if (box.isEmpty() === false && !isNaN(box.min.x)) {
       box.getCenter(center);
       distance = box.getBoundingSphere(sphere).radius;
+      localCenterY = (box.max.y - box.min.y) / 2;
     } else {
-      // Focusing on an Group, AmbientLight, etc
-
+      // Focusing on an AmbientLight, etc
       center.setFromMatrixPosition(target.matrixWorld);
       distance = 0.1;
+      localCenterY = target.position.y;
     }
 
     object.position.copy(
       target.localToWorld(
-        new THREE.Vector3(0, center.y + distance * 0.5, distance * 2.5)
+        new THREE.Vector3(0, localCenterY + distance * 0.5, distance * 2.5)
       )
     );
-    const pos = target.getWorldPosition(new THREE.Vector3());
-    pos.y = center.y;
-    object.lookAt(pos);
+    object.lookAt(center);
 
     scope.dispatchEvent(changeEvent);
   };


### PR DESCRIPTION
The calculation I did in #760 was not quite right.
The center was assumed to be in local coordinates but it is actually already in world coordinates, so localToWorld increased the y value so the camera was much too high. The issue is not much visible in a scene where all models are on the ground, it's much more visible on a model in the air. Even for models on the ground, that fixes the glitch when you start rotating after focusing an element.

Before
![focus_before](https://github.com/user-attachments/assets/3dcb984f-cf72-49f8-9c2f-be74db2a22e0)

After:
![focus_after](https://github.com/user-attachments/assets/30d983d2-8aa9-488c-89ef-67129e35e6c8)
