### PR TITLE
Allow dash in component instance id like bind__troika-text

### DIFF
--- a/src/components/components/AddComponent.js
+++ b/src/components/components/AddComponent.js
@@ -32,7 +32,7 @@ export default class AddComponent extends React.Component {
         id = id
           .trim()
           .toLowerCase()
-          .replace(/[^a-z0-9]/g, '');
+          .replace(/[^a-z0-9-]/g, '');
         // With the transform, id could be empty string, so we need to check again.
       }
       if (id) {


### PR DESCRIPTION
I wanted to use https://github.com/supermedium/superframe/tree/master/components/state
so I entered `troika-text` when adding the `bind` component, but it wrongly created `bind__troikatext` instead of `bind__troika-text` and so the bind component didn't work.
A dash in component instance id is allowed.
This PR fixes the issue @dmarcos 