### PR TITLE
Fix editing entity id, trigger the update only on blur and enter

### DIFF
--- a/src/components/components/CommonComponents.js
+++ b/src/components/components/CommonComponents.js
@@ -133,7 +133,7 @@ export default class CommonComponents extends React.Component {
               ID
             </label>
             <InputWidget
-              onChange={changeId}
+              onBlur={changeId}
               entity={entity}
               name="id"
               value={entity.id}

--- a/src/components/widgets/InputWidget.js
+++ b/src/components/widgets/InputWidget.js
@@ -5,6 +5,7 @@ export default class InputWidget extends React.Component {
   static propTypes = {
     id: PropTypes.string,
     name: PropTypes.string.isRequired,
+    onBlur: PropTypes.func,
     onChange: PropTypes.func,
     value: PropTypes.any
   };
@@ -12,13 +13,31 @@ export default class InputWidget extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: this.props.value || '' };
+    this.input = React.createRef();
   }
 
-  onChange = (e) => {
-    var value = e.target.value;
+  onChange = (event) => {
+    const value = event.target.value;
     this.setState({ value: value });
     if (this.props.onChange) {
       this.props.onChange(this.props.name, value);
+    }
+  };
+
+  onBlur = (event) => {
+    if (this.props.onBlur) {
+      const value = event.target.value;
+      this.props.onBlur(this.props.name, value);
+    }
+  };
+
+  onKeyDown = (event) => {
+    event.stopPropagation();
+
+    // enter
+    if (event.keyCode === 13) {
+      this.input.current.blur();
+      return;
     }
   };
 
@@ -32,10 +51,13 @@ export default class InputWidget extends React.Component {
     return (
       <input
         id={this.props.id}
+        ref={this.input}
         type="text"
         className="string"
         value={this.state.value}
+        onBlur={this.onBlur}
         onChange={this.onChange}
+        onKeyDown={this.onKeyDown}
       />
     );
   }


### PR DESCRIPTION
Fix editing entity id, trigger the update only on blur and enter, not on each keystroke.

This fixes the issue reported in https://github.com/c-frame/aframe-editor/issues/51 that updating the id of an entity causes another entity's id to be updated.