### PR TITLE
Be sure to not register again asset with same url, create a-assets if missing

### DIFF
--- a/src/components/modals/ModalTextures.js
+++ b/src/components/modals/ModalTextures.js
@@ -347,11 +347,11 @@ export default class ModalTextures extends React.Component {
               />
               {preview.type !== 'asset' && assetIdTaken && (
                 <div className="iderror">
-                  id already taken by another asset or entity
+                  Name already taken by another asset or entity
                 </div>
               )}
               {this.state.preview.name.length > 0 && !validId && (
-                <div className="iderror">id is not valid</div>
+                <div className="iderror">Name is not valid</div>
               )}
               {preview.type === 'asset' && (
                 <div className="iderror">Texture already loaded</div>

--- a/src/components/modals/ModalTextures.js
+++ b/src/components/modals/ModalTextures.js
@@ -274,10 +274,12 @@ export default class ModalTextures extends React.Component {
 
     let validId = isValidId(this.state.preview.name);
     let assetIdTaken =
+      validId && !!document.getElementById(this.state.preview.name);
+    let validAsset =
+      this.state.preview.loaded &&
       validId &&
-      this.state.preview.type !== 'asset' &&
-      !!document.getElementById(this.state.preview.name);
-    let validAsset = this.state.preview.loaded && !assetIdTaken;
+      !assetIdTaken &&
+      this.state.preview.type !== 'asset';
 
     let addNewAssetButton = this.state.addNewDialogOpened
       ? 'BACK'
@@ -333,6 +335,7 @@ export default class ModalTextures extends React.Component {
                     ? 'error'
                     : ''
                 }
+                readOnly={preview.type === 'asset'}
                 type="text"
                 value={this.state.preview.name}
                 onChange={this.onNameChanged}
@@ -342,13 +345,16 @@ export default class ModalTextures extends React.Component {
                   }
                 }}
               />
-              {assetIdTaken && (
+              {preview.type !== 'asset' && assetIdTaken && (
                 <div className="iderror">
                   id already taken by another asset or entity
                 </div>
               )}
               {this.state.preview.name.length > 0 && !validId && (
                 <div className="iderror">id is not valid</div>
+              )}
+              {preview.type === 'asset' && (
+                <div className="iderror">Texture already loaded</div>
               )}
               <img
                 ref={this.preview}
@@ -371,13 +377,9 @@ export default class ModalTextures extends React.Component {
                 <span />
               )}
               <br />
-              {preview.type === 'asset' ? (
-                <span>Texture already loaded</span>
-              ) : (
-                <button disabled={!validAsset} onClick={this.addNewAsset}>
-                  LOAD THIS TEXTURE
-                </button>
-              )}
+              <button disabled={!validAsset} onClick={this.addNewAsset}>
+                LOAD THIS TEXTURE
+              </button>
             </div>
           </div>
         </div>

--- a/src/components/modals/ModalTextures.js
+++ b/src/components/modals/ModalTextures.js
@@ -164,12 +164,6 @@ export default class ModalTextures extends React.Component {
     this.imageName.current.focus();
   };
 
-  onNameKeyUp = (event) => {
-    if (event.keyCode === 13 && this.isValidAsset()) {
-      this.addNewAsset();
-    }
-  };
-
   onNameChanged = (event) => {
     var state = this.state.preview;
     state.name = event.target.value;
@@ -201,12 +195,6 @@ export default class ModalTextures extends React.Component {
   onUrlChange = (e) => {
     this.setState({ newUrl: e.target.value });
   };
-
-  isValidAsset() {
-    let validUrl = isValidId(this.state.preview.name);
-    let validAsset = this.state.preview.loaded && validUrl;
-    return validAsset;
-  }
 
   addNewAsset = () => {
     if (this.state.preview.type === 'asset') {
@@ -284,8 +272,12 @@ export default class ModalTextures extends React.Component {
     let isOpen = this.state.isOpen;
     let preview = this.state.preview;
 
-    let validUrl = isValidId(this.state.preview.name);
-    let validAsset = this.isValidAsset();
+    let validId = isValidId(this.state.preview.name);
+    let assetIdTaken =
+      validId &&
+      this.state.preview.type !== 'asset' &&
+      !!document.getElementById(this.state.preview.name);
+    let validAsset = this.state.preview.loaded && !assetIdTaken;
 
     let addNewAssetButton = this.state.addNewDialogOpened
       ? 'BACK'
@@ -336,13 +328,28 @@ export default class ModalTextures extends React.Component {
               <input
                 ref={this.imageName}
                 className={
-                  this.state.preview.name.length > 0 && !validUrl ? 'error' : ''
+                  this.state.preview.name.length > 0 &&
+                  (!validId || assetIdTaken)
+                    ? 'error'
+                    : ''
                 }
                 type="text"
                 value={this.state.preview.name}
                 onChange={this.onNameChanged}
-                onKeyUp={this.onNameKeyUp}
+                onKeyUp={(event) => {
+                  if (event.keyCode === 13 && validAsset) {
+                    this.addNewAsset();
+                  }
+                }}
               />
+              {assetIdTaken && (
+                <div className="iderror">
+                  id already taken by another asset or entity
+                </div>
+              )}
+              {this.state.preview.name.length > 0 && !validId && (
+                <div className="iderror">id is not valid</div>
+              )}
               <img
                 ref={this.preview}
                 width="155px"

--- a/src/components/widgets/TextureWidget.js
+++ b/src/components/widgets/TextureWidget.js
@@ -1,66 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Events from '../../lib/Events';
-
-function getUrlFromId(assetId) {
-  return (
-    assetId.length > 1 &&
-    document.querySelector(assetId) &&
-    document.querySelector(assetId).getAttribute('src')
-  );
-}
-
-function GetFilename(url) {
-  if (url) {
-    var m = url.toString().match(/.*\/(.+?)\./);
-    if (m && m.length > 1) {
-      return m[1];
-    }
-  }
-  return '';
-}
-
-function insertNewAsset(type, id, src) {
-  var element = null;
-  switch (type) {
-    case 'img':
-      {
-        element = document.createElement('img');
-        element.id = id;
-        element.src = src;
-      }
-      break;
-  }
-  if (element) {
-    document.getElementsByTagName('a-assets')[0].appendChild(element);
-  }
-}
-
-function insertOrGetImageAsset(src) {
-  var id = GetFilename(src);
-  // Search for already loaded asset by src
-  var element = document.querySelector("a-assets > img[src='" + src + "']");
-
-  if (element) {
-    id = element.id;
-  } else {
-    // Check if first char of the ID is a number (Non a valid ID)
-    // In that case a 'i' preffix will be added
-    if (!isNaN(parseInt(id[0], 10))) {
-      id = 'i' + id;
-    }
-    if (document.getElementById(id)) {
-      var i = 1;
-      while (document.getElementById(id + '_' + i)) {
-        i++;
-      }
-      id += '_' + i;
-    }
-    insertNewAsset('img', id, src);
-  }
-
-  return id;
-}
+import { getUrlFromId } from '../../lib/assetsUtils';
 
 export default class TextureWidget extends React.Component {
   static propTypes = {
@@ -197,12 +138,8 @@ export default class TextureWidget extends React.Component {
       if (!image) {
         return;
       }
-      var value = image.value;
-      if (image.type !== 'asset') {
-        var assetId = insertOrGetImageAsset(image.src);
-        value = '#' + assetId;
-      }
 
+      var value = image.value;
       if (this.props.onChange) {
         this.props.onChange(this.props.name, value);
       }

--- a/src/lib/assetsUtils.js
+++ b/src/lib/assetsUtils.js
@@ -1,20 +1,49 @@
-export function insertNewAsset(
-  type,
-  id,
-  src,
-  anonymousCrossOrigin,
-  onLoadedCallback
-) {
-  var element = null;
+export function getUrlFromId(assetId) {
+  return (
+    assetId.length > 1 &&
+    document.querySelector(assetId) &&
+    document.querySelector(assetId).getAttribute('src')
+  );
+}
+
+export function getIdFromUrl(url) {
+  return document.querySelector("a-assets > [src='" + url + "']")?.id;
+}
+
+export function getFilename(url, converted = false) {
+  var filename = url.split('/').pop();
+  if (converted) {
+    filename = getValidId(filename);
+  }
+  return filename;
+}
+
+export function isValidId(id) {
+  // The correct re should include : and . but A-frame seems to fail while accessing them
+  var re = /^[A-Za-z]+[\w-]*$/;
+  return re.test(id);
+}
+
+export function getValidId(name) {
+  // info.name.replace(/\.[^/.]+$/, '').replace(/\s+/g, '')
+  return name
+    .split('.')
+    .shift()
+    .replace(/\s/, '-')
+    .replace(/^\d+\s*/, '')
+    .replace(/[\W]/, '')
+    .toLowerCase();
+}
+
+export function insertNewAsset(type, id, src, onLoadedCallback = undefined) {
+  let element;
   switch (type) {
     case 'img':
       {
         element = document.createElement('img');
         element.id = id;
         element.src = src;
-        if (anonymousCrossOrigin) {
-          element.crossOrigin = 'anonymous';
-        }
+        element.crossOrigin = 'anonymous';
       }
       break;
   }
@@ -25,6 +54,17 @@ export function insertNewAsset(
         onLoadedCallback();
       }
     };
-    document.getElementsByTagName('a-assets')[0].appendChild(element);
+
+    let assetsEl = document.querySelector('a-assets');
+    if (!assetsEl) {
+      assetsEl = document.createElement('a-assets');
+      var sceneEl = document.querySelector('a-scene');
+      if (!sceneEl) {
+        throw new Error('No a-scene element found to append a-assets to');
+      }
+      sceneEl.appendChild(assetsEl);
+    }
+
+    assetsEl.appendChild(element);
   }
 }

--- a/src/style/textureModal.styl
+++ b/src/style/textureModal.styl
@@ -94,6 +94,13 @@
   margin 8px 0
   width 144px
 
+.preview .iderror
+  background #fff
+  color #a00
+  margin-bottom 8px
+  padding 3px 5px
+  width 148px
+
 .preview button
   width 155px
 


### PR DESCRIPTION
Steps to reproduce:
- select yellow cube
- go to the material's src property and click the button to open the textures modal
- right click on crate image and copy url
- click LOAD TEXTURE
- paste the url and press enter (or you can also click on the crate image)
- it currently shows the "crate" name and pressing LOAD THIS TEXTURE will add a second time that asset with a different name. That's wrong.

What it should do is showing the existing asset id "crateImg" and not "crate" to not register the same asset a second time.
I now show the message "Texture already loaded" and the "LOAD THIS TEXTURE" button stays disabled in this case.
I also now handle the case "Name already taken by another asset or entity".

The code 

```js
if (image.type !== 'asset') {
  var assetId = insertOrGetImageAsset(image.src);
  value = '#' + assetId;
}
```
that is executed after selecting a texture that closes the modal probably took care of reusing the same asset in the past but it was a dead branch in the current code, `image.type` is always "asset" here because `props.onClose(value)` is called from `selectTexture` that is used only on registered assets.
I removed that code and the `insertOrGetImageAsset` function and reintroduced a check in the load texture step to check for existing asset with the same url.
I removed the duplicate `insertNewAsset/getFilename` functions and moved `getFilename`, `isValidId`, `getValidId`, `getUrlFromId` and added new `getIdFromUrl` to `assetsUtils.js` to be reused with other type of assets and not only img in the future (like selecting an audio for the sound component).
The `a-assets` element is now created if it doesn't exist, it gave an error previously.
The input field and preview is now cleared if you click on the BACK button.