### PR TITLE
Fix css rules that removed color widget inner padding

### DIFF
--- a/src/style/index.styl
+++ b/src/style/index.styl
@@ -232,16 +232,16 @@ body.aframe-inspector-opened
     width 50px
 
   /* Note these vendor-prefixed selectors cannot be grouped! */
-  input[type=color]-webkit-color-swatch
+  input[type=color]::-webkit-color-swatch
     border 0  /* To remove the gray border. */
 
-  input[type=color]-webkit-color-swatch-wrapper
+  input[type=color]::-webkit-color-swatch-wrapper
     padding 0  /* To remove the inner padding. */
 
-  input[type=color]-moz-color-swatch
+  input[type=color]::-moz-color-swatch
     border 0
 
-  input[type=color]-moz-focus-inner
+  input[type=color]::-moz-focus-inner
     border 0  /* To remove the inner border (specific to Firefox). */
     padding 0
 


### PR DESCRIPTION
Before
<img width="293" height="45" alt="Capture d’écran du 2025-11-11 20-04-11" src="https://github.com/user-attachments/assets/88065b58-3b09-43c1-911c-0f169b5678af" />

After
<img width="301" height="50" alt="Capture d’écran du 2025-11-11 20-06-12" src="https://github.com/user-attachments/assets/56ccda25-2a3b-4749-9c46-51d195b43fa3" />
