### PR TITLE
Put back the border on focused input for string and number

### DIFF
--- a/src/style/index.styl
+++ b/src/style/index.styl
@@ -193,11 +193,9 @@ body.aframe-inspector-opened
     font-size 13px
     padding 2px
 
-  input.stringfocus,
-  input.numberfocus
-    border 1px solid #20b1fb
-    color #fff
-    cursor auto
+  input.string:focus,
+  input.number:focus
+    border 1px solid #1faaf2
 
   input.error
     border 1px solid #a00


### PR DESCRIPTION
Before
<img width="301" height="50" alt="Capture d’écran du 2025-11-11 20-16-18" src="https://github.com/user-attachments/assets/99b0848e-0aed-4dd0-9797-9320e34524d6" />

After
<img width="301" height="50" alt="Capture d’écran du 2025-11-11 20-15-56" src="https://github.com/user-attachments/assets/002b67d4-cdf0-47cd-8839-2bf3204872b6" />
