### PR TITLE
Remove useless THREE.ImageUtils.crossOrigin line

### DIFF
--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -11,8 +11,6 @@ import CameraToolbar from './viewport/CameraToolbar';
 import TransformToolbar from './viewport/TransformToolbar';
 import ViewportHUD from './viewport/ViewportHUD';
 
-THREE.ImageUtils.crossOrigin = '';
-
 export default class Main extends React.Component {
   constructor(props) {
     super(props);


### PR DESCRIPTION
I did a search of ImageUtils.crossOrigin in threejs repo, nothing.
ImageUtils has two static functions getDataURL and sRGBToLinear that are not used anywhere in this code base or in aframe repo either. So that's just a useless line.