### PR TITLE
Use css variables to support adding a theme switcher

### DIFF
--- a/src/style/components.styl
+++ b/src/style/components.styl
@@ -1,8 +1,8 @@
 @import './lib';
 
 .components
-  background-color $bg
-  color $white
+  background-color var(--color-base-200)
+  color var(--color-base-content)
   height 100%
   overflow auto
   position fixed
@@ -13,7 +13,7 @@
   display flex
   justify-content space-between
   .entityPrint
-    color #fff
+    color var(--color-base-content)
 
 .collapsible-content
   padding 5px 0
@@ -24,7 +24,7 @@
   text-overflow ellipsis
   text-transform uppercase
   white-space nowrap
-  color #fff
+  color var(--color-base-content)
   font-weight 600
   vertical-align bottom !important
 
@@ -34,8 +34,8 @@
   gap 10px
 
 .collapsible .static
-  background $bglight
-  border-bottom 2px solid $bg
+  background var(--color-base-100)
+  border-bottom 2px solid var(--color-base-200)
   box-sizing content-box
   cursor pointer
   height 16px
@@ -43,7 +43,7 @@
   vertical-align bottom
   font-size 13px
   &:hover
-    background $bglighter
+    background var(--color-base-lighter)
 
 .collapsible .static
   margin 0
@@ -57,11 +57,11 @@
   width 0
 
 .collapsible.collapsed .static .collapse-button
-  border-left-color $white
+  border-left-color var(--color-base-content)
   margin-top 4px
 
 .collapsible:not(.collapsed) .static .collapse-button
-  border-top-color $white
+  border-top-color var(--color-base-content)
   margin-top 7px
 
 .propertyRow
@@ -112,8 +112,8 @@
   input[type=number],
   input.string,
   input.number
-    background $bgdark
-    color $primary
+    background var(--color-base-300)
+    color var(--color-primary)
     min-height 26px
     padding-bottom 1px
     padding-left 5px
@@ -140,7 +140,7 @@
     letter-spacing 1px
 
 .propertyRowDefined .text
-  color #FAFAFA
+  color var(--color-property-defined)
   font-weight 600
 
 #addComponentContainer
@@ -149,25 +149,26 @@
   flex-direction column
   justify-content center
   padding 20px 10px
-  background $bgdark
+  background var(--color-base-200)
+  border-top 1px solid var(--color-base-100)
 
   #addComponent
     text-align left
     width 200px
     .select__control
-      background #161616
+      background var(--color-base-300)
       height 35px
-      color $primary
+      color var(--color-primary)
 
   #addComponentHeader
     font-size 15px
-    margin 5px 0 10px 0
+    margin 0 0 10px 0
 
   input[type=text]:focus
     box-shadow none
 
 .Select-menu-outer .is-focused span
-  color #fff
+  color var(--color-base-content)
 
 .component-title
   align-items center
@@ -188,8 +189,6 @@
     padding-left 5px
   .entityName
     max-width 160px
-  .entityIcons
-    color #FAFAFA
 
 #mixinSelect
   width 160px

--- a/src/style/entity.styl
+++ b/src/style/entity.styl
@@ -13,10 +13,10 @@
   white-space nowrap
 
 [data-entity-name-type="id"]
-  color $red
+  color var(--color-error)
 
 [data-entity-name-type="class"]
-  color $green
+  color var(--color-success)
 
 [data-entity-name-type="mixin"]
-  color $orange
+  color var(--color-warning)

--- a/src/style/help.styl
+++ b/src/style/help.styl
@@ -23,18 +23,18 @@
   position relative
 
 .help-key span
-  background-color #2e2e2e
+  background-color var(--color-neutral)
   background-repeat repeat-x
-  border 1px solid #666
+  border 1px solid var(--color-neutral-content)
   border-radius 3px
   box-shadow 0 0 5px #000
-  color #999
+  color var(--color-neutral-content)
   display inline-block
   font-size 12px
   padding 0 8px
   text-align center
 
 .help-key-def
-  color #bbb
+  color var(--color-base-content)
   display inline-block
   margin-left 1em

--- a/src/style/index.styl
+++ b/src/style/index.styl
@@ -11,13 +11,48 @@ body.aframe-inspector-opened,
   font-family BlinkMacSystemFont, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif
 
 body.aframe-inspector-opened
-  background $bgdark
-  color #fff
+  background var(--color-base-200)
+  color var(--color-base-content)
   font-size 12px
   margin 0
   overflow hidden
 
+/* :where(:root) has zero specificity compared to :root, so any user defined :root will override the below rule */
+:where(:root) {
+  color-scheme dark
+  --color-base-100: #333;
+  --color-base-200: #242424;
+  --color-base-300: #1d1d1d;
+  --color-base-content: #c3c3c3;
+  --color-primary: #1faaf2;
+  --color-primary-content: #fff;
+  --color-secondary: #92374d;
+  --color-secondary-content: #fafafa;
+  --color-accent: #155373;
+  --color-accent-content: #fff;
+  --color-neutral: #333;
+  --color-neutral-content: #aaa;
+  --color-info: #2cb7ff;
+  --color-info-content: #fff;
+  --color-success: #8b8;
+  --color-success-content: #000;
+  --color-warning: #d66853;
+  --color-warning-content: #000;
+  --color-error: #92374d;
+  --color-error-content: #000;
+}
+
 #aframeInspector
+  --color-base-lighter: unquote("color-mix(in oklab, var(--color-base-100) 90%, white 10%)");
+  --color-primary-hover: unquote("color-mix(in oklab, var(--color-primary) 90%, black 10%)");
+  --color-secondary-hover: unquote("color-mix(in oklab, var(--color-secondary) 90%, black 10%)");
+  --color-accent-hover: unquote("color-mix(in oklab, var(--color-accent) 70%, black 30%)");
+  --color-neutral-hover: unquote("color-mix(in oklab, var(--color-neutral) 90%, black 10%)");
+  --color-property-defined: light-dark(
+    unquote("color-mix(in oklab, var(--color-base-content) 10%, black 90%)"),   /* darker for light theme */
+    unquote("color-mix(in oklab, var(--color-base-content) 10%, white 90%)")    /* lighter for dark theme */
+  )
+
   @import './scenegraph';
   @import './components';
   @import './entity';
@@ -46,7 +81,7 @@ body.aframe-inspector-opened
 
   hr
     border 0
-    border-top 1px solid #ccc
+    border-top 1px solid var(--color-base-content)
 
   a
     cursor pointer
@@ -61,13 +96,6 @@ body.aframe-inspector-opened
     tab-size 4
     white-space pre
     word-wrap normal
-
-  textarea.success
-    border-color #8b8 !important
-
-  textarea.fail
-    background-color rgba(255, 0, 0, 0.05)
-    border-color #f00 !important
 
   textarea,
   input
@@ -93,9 +121,9 @@ body.aframe-inspector-opened
       user-select none
 
   .toggle-edit
-    background-color $red
+    background-color var(--color-secondary)
     box-sizing content-box
-    color #FAFAFA
+    color var(--color-secondary-content)
     font-size 13px
     left 3px
     line-height 16px
@@ -109,12 +137,12 @@ body.aframe-inspector-opened
     z-index 999999999
 
   .toggle-edit:hover
-    background-color rgb(228, 43, 90)
+    background-color var(--color-secondary-hover)
 
   .try-editor-btn
-    background-color $red
+    background-color var(--color-secondary)
     box-sizing content-box
-    color #FAFAFA
+    color var(--color-secondary-content)
     font-size 16px
     line-height 24px
     margin 0
@@ -127,13 +155,13 @@ body.aframe-inspector-opened
     justify-content center
 
   .try-editor-btn:hover
-    background-color rgb(228, 43, 90)
-    color #FAFAFA
+    background-color var(--color-secondary-hover)
+    color var(--color-secondary-content)
 
   .sponsor-btn
-    background-color #ffffff
+    background-color var(--color-neutral)
     box-sizing content-box
-    color #000000
+    color var(--color-neutral-content)
     font-size 13px
     left 127px
     line-height 16px
@@ -154,13 +182,13 @@ body.aframe-inspector-opened
       color rgb(219, 97, 162)
 
   .sponsor-btn:hover
-    background-color rgb(228, 43, 90)
-    color #FAFAFA
+    background-color var(--color-neutral-hover)
+    color var(--color-neutral-content)
 
   input
     background-color transparent
-    border 1px solid #555
-    color #fff
+    border 1px solid var(--color-base-200)
+    color var(--color-base-content)
 
   input,
   .texture canvas
@@ -180,14 +208,14 @@ body.aframe-inspector-opened
     margin 0
     height 18px
     width 18px
-    border 1px solid $white
+    border 1px solid var(--color-base-300)
     border-radius 0
-    background transparent
+    background var(--color-base-300)
     position relative
 
     &:checked
-        border 1px solid $primary
-        background $primary
+        border 1px solid var(--color-base-300)
+        background var(--color-primary)
 
         &::after
             content ''
@@ -206,35 +234,35 @@ body.aframe-inspector-opened
   input.number
     background-color transparent !important
     border 0
-    color #2cb7ff !important
+    color var(--color-primary) !important
     cursor col-resize
     font-size 13px
     padding 2px
 
   input.string:focus,
   input.number:focus
-    border 1px solid $primary
+    border 1px solid var(--color-primary)
 
   input.error
-    border 1px solid #a00
+    border 1px solid var(--color-error)
 
   #sidebar
-    background $bg
+    background var(--color-base-200)
     width 331px
 
   input,
   textarea,
   select
-    background $black
+    background var(--color-base-300)
     border 1px solid transparent
-    color #888
+    color var(--color-base-content)
 
   select
-    background $bglighter
+    background var(--color-base-lighter)
 
   input[type=color]
-    background-color #333
-    border 1px solid #111
+    background-color var(--color-base-100)
+    border 1px solid var(--color-base-300)
     height 28px
     cursor pointer
 
@@ -263,13 +291,13 @@ body.aframe-inspector-opened
     visibility hidden
 
   a.button
-    color #bcbcbc
+    color var(--color-base-content)
     font-size 16px
     line-height 1em
     text-decoration none
 
     &:hover
-      color $primary
+      color var(--color-primary)
 
   @keyframes animateopacity
     from { opacity: 0 }
@@ -314,14 +342,14 @@ body.aframe-inspector-opened
     z-index 9998
 
     a
-      background-color #262626
-      color #bcbcbc
+      background-color var(--color-base-200)
+      color var(--color-base-content)
       padding 5px
       z-index 9998
 
     a.hover
-      background-color #1faaf2
-      color #fff
+      background-color var(--color-primary)
+      color var(--color-primary-content)
 
   .toggle-sidebar.left
     top 0

--- a/src/style/lib.styl
+++ b/src/style/lib.styl
@@ -1,23 +1,3 @@
-$primary=#1faaf2
-$primaryhover=lighten(#1faaf2, 35%)
-
-$bg=#242424
-$bgdark=#1d1d1d
-$bglight=#333
-$bglighter=#393939
-
-$red=#92374d
-$green=#514b23
-$orange=#d66853
-
-$black=#222
-$gray=#262626
-$grayalt=#323232
-$grayhover=#444
-
-$lightgray=#AAA
-$white=#c3c3c3
-
 $normalfont=system-ui, BlinkMacSystemFont, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif
 $monospace=system-ui, BlinkMacSystemFont, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif
 

--- a/src/style/scenegraph.styl
+++ b/src/style/scenegraph.styl
@@ -1,7 +1,7 @@
 @import './lib';
 
 #toolbar
-  background-color $bg
+  background-color var(--color-base-200)
 
   .toolbarActions
     padding 5px 10px
@@ -14,8 +14,8 @@
       cursor default
 
 #scenegraph
-  background $bg
-  border-top 1px solid #111
+  background var(--color-base-200)
+  border-top 1px solid var(--color-base-300)
   display flex
   flex-direction column
   overflow auto
@@ -23,7 +23,7 @@
   width 230px
 
   .entity
-    background $bg
+    background var(--color-base-200)
     box-sizing border-box
     cursor pointer
     display flex
@@ -36,18 +36,19 @@
     white-space nowrap
 
     &:hover
-      background #1d2f39
+      background var(--color-accent-hover)
+      color var(--color-accent-content)
 
     &.active
-      background-color #155373
-      color #fff
+      background-color var(--color-accent)
+      color var(--color-accent-content)
       .entityActions
         align-items center
         display flex
         padding-right 2px
 
         a.button:hover
-          color $primary
+          color var(--color-primary)
 
     &.novisible
       &.active
@@ -55,7 +56,7 @@
         svg,
         .collapsespace,
         .id
-          color #999
+          color #626262
 
       &:not(.active)
         span,
@@ -65,7 +66,7 @@
           color #626262
 
   .component:hover
-    color $primary
+    color var(--color-primary)
 
   .entityIcons
     margin-left 2px
@@ -74,21 +75,24 @@
     display none
 
     .button
-      color #fff
+      color var(--color-base-content)
       font-size 12px
       margin-left 6px
 
   .id
-    color #ccc
+    color var(--color-base-content)
 
   .option.active .id
-    color #fff
+    color var(--color-base-content)
 
   .collapsespace
-    color #eee
+    color var(--color-base-content)
     display inline-block
     text-align center
     width 14px
+
+  .fa-eye
+    color var(--color-base-content)
 
   .search
     padding 5px
@@ -97,12 +101,15 @@
     display flex
 
     input
-      color $white
-      background $bgdark
+      color var(--color-primary)
+      background var(--color-base-300)
       border-radius 0
       box-sizing border-box
       padding 5px 10px
       width 100%
+
+    >svg
+      color var(--color-base-content)
 
     >svg, a.button
       position absolute
@@ -110,8 +117,8 @@
       top 10px
 
   .outliner
-    background $bg
-    color $white
+    background var(--color-base-200)
+    color var(--color-base-content)
     cursor default
     flex 1 1 auto
     font-size 13px

--- a/src/style/select.styl
+++ b/src/style/select.styl
@@ -9,6 +9,7 @@
   font-size 13px
 
 .select__indicator
+  color var(--color-base-content)
   height 26px
 
 .select__indicator-separator
@@ -19,17 +20,17 @@
 
 .select__control,
 .select__menu
-  background $bgdark
+  background var(--color-base-300)
 
 .select__option
   padding 5px 10px
 
 .select__placeholder,
 .select__menu
-  color $white
+  color var(--color-base-content)
 
 .select__single-value
-  color $primary
+  color var(--color-primary)
 
 .select__control--is-focused
   box-shadow none !important
@@ -41,11 +42,12 @@
   font-size 11px
 
 .select__option--is-focused
-  background #155373
+  background var(--color-accent-hover)
+  color var(--color-accent-content)
 
 .select__option--is-selected
-  background $primary
-  color $white
+  background var(--color-accent)
+  color var(--color-accent-content)
 
 .select__value-container
   height 26px
@@ -58,12 +60,12 @@
   padding 3px 8px
 
 .select__multi-value
-  background $bg
-  color $primary
+  background var(--color-base-200)
+  color var(--color-primary)
 
 .select__multi-value__label
-  color $primary
+  color var(--color-primary)
 
 .select__multi-value__remove:hover
-  color #fff
-  background $bg
+  color var(--color-base-content)
+  background var(--color-base-200)

--- a/src/style/textureModal.styl
+++ b/src/style/textureModal.styl
@@ -24,39 +24,40 @@
   animation animatetop 0.2s ease-out
   animation-duration 0.2s
   animation-name animatetop
-  background-color #232323
+  background-color var(--color-base-200)
   box-shadow 0 4px 8px 0 rgba(0, 0, 0, 0.5), 0 6px 20px 0 rgba(0, 0, 0, 0.5)
   margin auto
   overflow hidden
   padding 0
 
 .close
-  color white
+  color var(--color-base-content)
   float right
   font-size 28px
   font-weight bold
 
 .close:hover,
 .close:focus
-  color #08f
+  color var(--color-primary)
   cursor pointer
   text-decoration none
 
 .modal-header
-  color white
+  color var(--color-base-content)
   padding 2px 16px
 
 .modal-body
+  color var(--color-base-content)
   overflow auto
   padding 16px
 
 .modal-footer
-  color white
+  color var(--color-base-content)
   padding 2px 16px
 
 /* Gallery */
 .gallery
-  background #232323
+  background var(--color-base-200)
   display flex
   flex-wrap wrap
   margin 15px auto 0
@@ -77,10 +78,10 @@
 
 .gallery li.selected,
 .gallery li:hover
-  box-shadow 0 0 0 2px #1eaaf1
+  box-shadow 0 0 0 2px var(--color-primary)
 
 .gallery li .detail
-  background-color #323232
+  background-color var(--color-base-100)
   margin 0
   min-height 60px
   padding 3px 10px
@@ -95,8 +96,10 @@
   width 144px
 
 .preview .iderror
-  background #fff
-  color #a00
+  background unquote("color-mix(in oklab, var(--color-error) 8%, var(--color-base-300))");
+  text-align center
+  color var(--color-error)
+  font-weight 600
   margin-bottom 8px
   padding 3px 5px
   width 148px
@@ -105,7 +108,7 @@
   width 155px
 
 .preview .detail .title
-  color #fff
+  color var(--color-base-content)
   display inline-block
   max-width 155px
   overflow hidden
@@ -114,10 +117,10 @@
 
 .gallery li.selected .detail,
 .gallery li:hover .detail
-  background-color #444
+  background-color var(--color-base-lighter)
 
 .gallery li .detail span
-  color #777
+  color var(--color-base-content)
   display block
   margin-top 4px
   overflow hidden
@@ -127,10 +130,11 @@
 
 .gallery li.selected .detail span,
 .gallery li:hover .detail span
-  color #888
+  color var(--color-base-content)
 
 .gallery li .detail span.title
-  color #fff !important
+  color var(--color-property-defined)
+  font-weight 600
 
 .modal button
   appearance none
@@ -147,27 +151,26 @@
   outline none
 
 .modal button
-  background-color #1eaaf1
+  background-color var(--color-primary)
   border none
-  color #fff
+  color var(--color-primary-content)
 
 .modal button:hover,
 .modal button.hover
-  background-color #346392
-  text-shadow -1px 1px #27496d
+  background-color var(--color-primary-hover)
 
 .modal button:active,
 .modal button.active
-  background-color #27496d
-  text-shadow -1px 1px #193047
+  background-color var(--color-primary-hover)
 
 .modal button:disabled
-  background-color #888
-  cursor none
+  background-color #666
+  color #fff
+  cursor default
 
 .newimage
-  background-color #323232
-  color #bcbcbc
+  background-color var(--color-base-100)
+  color var(--color-base-content)
   display flex
   font-size 13px
   justify-content space-between
@@ -176,7 +179,7 @@
   padding 10px
 
 .newimage input
-  color #1eaaf1
+  color var(--color-primary)
   padding 3px 5px
 
 .texture canvas + input
@@ -213,5 +216,5 @@
   width 350px
 
 .texture canvas
-  border 1px solid $bglight
+  border 1px solid var(--color-base-100)
   cursor pointer

--- a/src/style/viewport.styl
+++ b/src/style/viewport.styl
@@ -2,8 +2,8 @@
 
 #viewportBar
   align-items center
-  background-color $bg
-  color $white
+  background-color var(--color-base-200)
+  color var(--color-base-content)
   display flex
   flex-grow 2
   height 32px
@@ -21,14 +21,14 @@
       padding 8px
 
     &:not(.active) svg:hover
-      background-color $grayhover
+      background-color var(--color-base-lighter)
 
   .active svg
-    background-color $primary
-    color #fff
+    background-color var(--color-primary)
+    color var(--color-primary-content)
 
   .active:hover svg
-    color #fff !important
+    color var(--color-primary-content) !important
 
 .local-transform
   display flex
@@ -37,7 +37,7 @@
   padding 0 10px
 
 .local-transform label
-  color $lightgray
+  color var(--color-base-content)
 
 #cameraSelect
   cursor pointer
@@ -52,9 +52,9 @@
   .select__control
     background none
   .select__single-value
-    color $white
+    color var(--color-base-content)
     &:hover
-      color $primary
+      color var(--color-primary)
 
 #viewportHud
   display none

--- a/src/style/widgets.styl
+++ b/src/style/widgets.styl
@@ -1,21 +1,21 @@
 @import './lib';
 
 .Select-control
-  background-color #222 !important
+  background-color var(--color-base-300) !important
   border none
   border-radius 0
-  color $primary
+  color var(--color-primary)
   font-family $monosapce
 
 .Select-menu-outer
   border none
 
 .Select-menu-outer .is-focused
-  background-color $primary !important
-  color $white
+  background-color var(--color-primary) !important
+  color var(--color-base-content)
 
 .Select-option
-  background-color #222 !important
+  background-color var(--color-base-300) !important
 
 .select-widget
   display inline-block
@@ -23,7 +23,7 @@
 
 .Select-placeholder,
 .Select--single > .Select-control .Select-value
-  color $primary !important
+  color var(--color-primary) !important
 
 .Select-value-label
-  color $primary !important
+  color var(--color-primary) !important


### PR DESCRIPTION
Use css variables to support adding a theme switcher. (in a separate PR #835)
The variables names are those from https://daisyui.com so if your website is using daisyui, the inspector will be in your theme colors.

Example, if you have on your page
```html
    <style>
      /* You can also create your theme with https://daisyui.com/theme-generator
       * The default theme will be in this case your generated theme and not the aframe default theme.
       */
      :root {
        color-scheme: light;
        --color-base-100: oklch(100% 0 0);
        --color-base-200: oklch(93% 0 0);
        --color-base-300: oklch(86% 0 0);
        --color-base-content: oklch(22.389% 0.031 278.072);
        --color-primary: oklch(58% 0.158 241.966);
        --color-primary-content: oklch(100% 0 0);
        --color-secondary: oklch(55% 0.046 257.417);
        --color-secondary-content: oklch(100% 0 0);
        --color-accent: oklch(60% 0.118 184.704);
        --color-accent-content: oklch(100% 0 0);
        --color-neutral: oklch(0% 0 0);
        --color-neutral-content: oklch(100% 0 0);
        --color-info: oklch(60% 0.126 221.723);
        --color-info-content: oklch(100% 0 0);
        --color-success: oklch(62% 0.194 149.214);
        --color-success-content: oklch(100% 0 0);
        --color-warning: oklch(85% 0.199 91.936);
        --color-warning-content: oklch(0% 0 0);
        --color-error: oklch(70% 0.191 22.216);
        --color-error-content: oklch(0% 0 0);
        --radius-selector: 0.25rem;
        --radius-field: 0.25rem;
        --radius-box: 0.25rem;
        --size-selector: 0.25rem;
        --size-field: 0.25rem;
        --border: 1px;
        --depth: 0;
        --noise: 0;
      }
    </style>
```
it will give
![anoth_theme](https://github.com/user-attachments/assets/ebc65c8a-8328-411a-bd7c-ce22f1d7918c)
