### PR TITLE
Fix g-flag regex in getValidId and CSS selector injection in getIdFromUrl

### DIFF
--- a/src/lib/assetsUtils.js
+++ b/src/lib/assetsUtils.js
@@ -7,7 +7,8 @@ export function getUrlFromId(assetId) {
 }
 
 export function getIdFromUrl(url) {
-  return document.querySelector("a-assets > [src='" + url + "']")?.id;
+  const escaped = url.replace(/'/g, "\\'");
+  return document.querySelector(`a-assets > [src='${escaped}']`)?.id;
 }
 
 export function getFilename(url, converted = false) {
@@ -20,19 +21,23 @@ export function getFilename(url, converted = false) {
 
 export function isValidId(id) {
   // The correct re should include : and . but A-frame seems to fail while accessing them
-  var re = /^[A-Za-z]+[\w-]*$/;
+  var re = /^[A-Za-z_]+[\w-]*$/;
   return re.test(id);
 }
 
 export function getValidId(name) {
-  // info.name.replace(/\.[^/.]+$/, '').replace(/\s+/g, '')
-  return name
-    .split('.')
-    .shift()
-    .replace(/\s/, '-')
-    .replace(/^\d+\s*/, '')
-    .replace(/[\W]/, '')
-    .toLowerCase();
+  return (
+    name
+      .split('.')
+      .shift()
+      // Replace spaces with hyphens
+      .replace(/\s+/g, '-')
+      // Remove characters that are not letters (A–Z, a–z), numbers (0–9), underscore (_), and hyphen (-)
+      .replace(/[^\w-]+/g, '')
+      // Strip leading hyphens and digits
+      .replace(/^[-\d]+/, '')
+      .toLowerCase()
+  );
 }
 
 export function insertNewAsset(type, id, src, onLoadedCallback = undefined) {


### PR DESCRIPTION
### Allow id starting with _  in `isValidId`
id starting with _ is valid

### Regex missing `g` flag in `getValidId`

The `.replace(/\s/, '-')` and `.replace(/[\W]/, '')` calls only replaced the **first** match because they were missing the `g` (global) flag.

**Example** with filename `"9 -8 cool test.jpg"`:

Old (no `g` flag):
```
"9 -8 cool test"    → split('.').shift()
"9--8 cool test"    → replace(/\s/, '-')     — only first space replaced
"--8 cool test"     → replace(/^\d+\s*/, '') — strips "9"
"-8 cool test"      → replace(/[\W]/, '')    — removes first '-'
```
Result: `"8 cool test"` — starts with a digit and has spaces, invalid CSS selector ID.

New:
```
"9 -8 cool test"    → split('.').shift()
"9--8-cool-test"    → replace(/\s+/g, '-')      — spaces → hyphens
"9--8-cool-test"    → replace(/[^\w-]+/g, '')    — nothing to remove here
"cool-test"         → replace(/^[-\d]+/, '')     — strips leading "9--8-"
```
Result: `"cool-test"` — valid, and preserves word separation with hyphens.

###  CSS selector injection in `getIdFromUrl`

If `url` contains a single quote, the `querySelector` call throws a `SyntaxError`:

```js
// Old code:
document.querySelector("a-assets > [src='" + url + "']")
```

With a URL like `https://example.com/it's-a-photo.jpg`, the browser does NOT encode
the `'` in the `src` attribute, so the selector becomes invalid:

```
a-assets > [src='https://example.com/it's-a-photo.jpg']
                                        ^ breaks here
```

**Fix:** Escape single quotes before interpolating into the selector:

```js
const escaped = url.replace(/'/g, "\\'");
document.querySelector(`a-assets > [src='${escaped}']`)
```

Vincent: I tested that one in the console:
```js
const img=document.createElement('img')
img.src = "https://example.com/it's-a-photo.jpg"
document.querySelector('a-assets').appendChild(img)
document.querySelector("a-assets > img[src='https://example.com/it's-a-photo.jpg'")
Uncaught SyntaxError: Failed to execute 'querySelector' on 'Document': 'a-assets > img[src='￼https://example.com/it's-a-photo.jpg'' is not a valid selector.
document.querySelector("a-assets > img[src='https://example.com/it\\'s-a-photo.jpg'")
<img src=​"https:​/​/​example.com/​it's-a-photo.jpg">​
```