### PR TITLE
Fix crash in selectionBox when gltf-model loads after entity is detached

### DIFF
--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -167,9 +167,10 @@ export function Viewport(inspector) {
       } else if (object.el.hasAttribute('gltf-model')) {
         const listener = (event) => {
           if (event.target !== object.el) return; // we got an event for a child, ignore
+          object.el.removeEventListener('model-loaded', listener);
+          if (object.parent === null) return; // entity was detached before model loaded
           selectionBox.setFromObject(object);
           selectionBox.visible = true;
-          object.el.removeEventListener('model-loaded', listener);
         };
         object.el.addEventListener('model-loaded', listener);
       }


### PR DESCRIPTION
Very rare case but could happen when you undo/redo a reparent action very quickly in aframe-editor. Here in the inspector that's probably even harder to reproduce, maybe copy an entity having gltf-model, paste and delete enter right away but with the confirmation modal it leave enough time to not produce the error.