### PR TITLE
Material assets support: property widget, materials modal, asset deletion

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -77,6 +77,8 @@
         <a-mixin id="purple" material="color: #93648D"></a-mixin>
         <a-mixin id="short" scale="1 0.5 1"></a-mixin>
         <a-mixin id="yellow" material="color: #FFC65D"></a-mixin>
+        <a-material id="gold" color="#FFC65D" metalness="0.9" roughness="0.2"></a-material>
+        <a-material id="crateMat" src="#crateImg" roughness="0.9"></a-material>
         <img id="crateImg" src="https://aframe.io/sample-assets/assets/images/wood/crate.gif" crossorigin="true">
         <img id="floorImg" src="https://aframe.io/sample-assets/assets/images/terrain/grasslight-big.jpg" crossorigin="true">
       </a-assets>
@@ -92,6 +94,12 @@
       <a-box src="https://aframe.io/sample-assets/assets/images/bricks/brick_bump.jpg" position="-5 5 -2" width="1" color="#F16745"></a-box>
       <a-box id="aBox" position="0 2 0" height="2" color="#FFC65D"></a-box>
       <a-plane id="smiley" position="2.5 2 0" width="1" height="1" material="src: #canvasTexture" draw-smiley="canvas: #canvasTexture"></a-plane>
+
+      <!-- Shared material assets. -->
+      <a-entity id="goldBox" geometry="primitive: box" material="material: #gold" position="0 5 -2"></a-entity>
+      <a-entity id="goldSphere" geometry="primitive: sphere; radius: 0.5" material="material: #gold" position="1.5 5 -2"></a-entity>
+      <a-entity id="crateBox" geometry="primitive: box" material="material: #crateMat" position="-1.5 5 -2"></a-entity>
+      <a-entity id="inlineBox" geometry="primitive: box" material="material: material(shader: flat; color: #EF2D5E)" position="-3 5 -2"></a-entity>
 
       <!-- Models. -->
       <a-entity class="boxClass" geometry="primitive: box" material="src: #crateImg" position="3 4 0"></a-entity>

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -236,16 +236,18 @@ export default class Main extends React.Component {
           isOpen={this.state.isModalSponsorOpen}
           onClose={this.onCloseModalSponsor}
         />
-        <ModalTextures
-          isOpen={this.state.isModalTexturesOpen}
-          selectedTexture={this.state.selectedTexture}
-          onClose={this.onModalTextureOnClose}
-        />
         <ModalMaterials
           isOpen={this.state.isModalMaterialsOpen}
           selectedMaterial={this.state.selectedMaterial}
           pickEnabled={!!this.state.materialOnClose}
           onClose={this.onModalMaterialsClose}
+        />
+        {/* Rendered after ModalMaterials so it stacks on top when the textures
+            modal is opened from a map property in the materials modal. */}
+        <ModalTextures
+          isOpen={this.state.isModalTexturesOpen}
+          selectedTexture={this.state.selectedTexture}
+          onClose={this.onModalTextureOnClose}
         />
       </div>
     );

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -4,6 +4,7 @@ import { AwesomeIcon } from './AwesomeIcon';
 import Events from '../lib/Events';
 import ComponentsSidebar from './components/Sidebar';
 import ModalTextures from './modals/ModalTextures';
+import ModalMaterials from './modals/ModalMaterials';
 import ModalHelp from './modals/ModalHelp';
 import ModalSponsor from './modals/ModalSponsor';
 import SceneGraph from './scenegraph/SceneGraph';
@@ -21,6 +22,7 @@ export default class Main extends React.Component {
       isHelpOpen: false,
       isModalSponsorOpen: false,
       isModalTexturesOpen: false,
+      isModalMaterialsOpen: false,
       sceneEl: AFRAME.scenes[0],
       visible: {
         scenegraph: true,
@@ -75,6 +77,17 @@ export default class Main extends React.Component {
       }.bind(this)
     );
 
+    Events.on(
+      'openmaterialsmodal',
+      function (selectedMaterial, materialOnClose) {
+        this.setState({
+          selectedMaterial: selectedMaterial,
+          isModalMaterialsOpen: true,
+          materialOnClose: materialOnClose
+        });
+      }.bind(this)
+    );
+
     Events.on('entityselect', (entity) => {
       this.setState({ entity: entity });
     });
@@ -96,6 +109,13 @@ export default class Main extends React.Component {
     this.setState({ isModalTexturesOpen: false });
     if (this.state.textureOnClose) {
       this.state.textureOnClose(value);
+    }
+  };
+
+  onModalMaterialsClose = (value) => {
+    this.setState({ isModalMaterialsOpen: false });
+    if (this.state.materialOnClose) {
+      this.state.materialOnClose(value);
     }
   };
 
@@ -220,6 +240,12 @@ export default class Main extends React.Component {
           isOpen={this.state.isModalTexturesOpen}
           selectedTexture={this.state.selectedTexture}
           onClose={this.onModalTextureOnClose}
+        />
+        <ModalMaterials
+          isOpen={this.state.isModalMaterialsOpen}
+          selectedMaterial={this.state.selectedMaterial}
+          pickEnabled={!!this.state.materialOnClose}
+          onClose={this.onModalMaterialsClose}
         />
       </div>
     );

--- a/src/components/components/Component.js
+++ b/src/components/components/Component.js
@@ -93,9 +93,18 @@ export default class Component extends React.Component {
       );
     }
 
+    // When the material component uses a material asset (material property set),
+    // every other property is ignored, entirely defined by the <a-material>; only
+    // show the material property.
+    const usesMaterialAsset =
+      this.props.name === 'material' && !!componentData.data.material;
+
     return Object.keys(componentData.schema)
       .sort()
       .filter((propertyName) => shouldShowProperty(propertyName, componentData))
+      .filter(
+        (propertyName) => !usesMaterialAsset || propertyName === 'material'
+      )
       .map((propertyName) => (
         <PropertyRow
           key={propertyName}

--- a/src/components/components/PropertyRow.js
+++ b/src/components/components/PropertyRow.js
@@ -9,6 +9,7 @@ import CopyToClipboardButton from '../CopyToClipboardButton';
 import BooleanWidget from '../widgets/BooleanWidget';
 import ColorWidget from '../widgets/ColorWidget';
 import InputWidget from '../widgets/InputWidget';
+import MaterialWidget from '../widgets/MaterialWidget';
 import NumberWidget from '../widgets/NumberWidget';
 import SelectWidget from '../widgets/SelectWidget';
 import TextureWidget from '../widgets/TextureWidget';
@@ -116,6 +117,10 @@ export default class PropertyRow extends React.Component {
     }
     if (type === 'map') {
       return <TextureWidget {...widgetProps} />;
+    }
+    if (type === 'material') {
+      // widgetProps contains onBlur (material is a selector-like type).
+      return <MaterialWidget {...widgetProps} />;
     }
 
     switch (type) {

--- a/src/components/components/PropertyRow.js
+++ b/src/components/components/PropertyRow.js
@@ -69,7 +69,12 @@ export default class PropertyRow extends React.Component {
   getWidget() {
     const props = this.props;
     const type = this.getType();
-    const isSelectorType = type === 'selector' || type === 'selectorAll';
+    // The material type behaves like a selector (`#myMaterial` or an inline
+    // `material(...)` definition): edit the raw string and commit on blur so
+    // partial selectors typed by the user are not committed keystroke by
+    // keystroke (which would detach the entity from its shared material).
+    const isSelectorType =
+      type === 'selector' || type === 'selectorAll' || type === 'material';
 
     const value = isSelectorType
       ? props.entity.getDOMAttribute(props.componentname)?.[props.name]

--- a/src/components/modals/Modal.js
+++ b/src/components/modals/Modal.js
@@ -31,6 +31,7 @@ export default class Modal extends React.Component {
   handleGlobalKeydown = (event) => {
     if (
       this.state.isOpen &&
+      this.isTopmostModal() &&
       (event.keyCode === 27 ||
         (this.props.extraCloseKeyCode &&
           event.keyCode === this.props.extraCloseKeyCode))
@@ -42,6 +43,16 @@ export default class Modal extends React.Component {
     }
   };
 
+  // Modals can be stacked (e.g., the textures modal opened from the materials
+  // modal); only the topmost open modal should react to ESC or outside clicks.
+  isTopmostModal = () => {
+    const openModals = document.querySelectorAll('.modal:not(.hide)');
+    return (
+      openModals.length > 0 &&
+      openModals[openModals.length - 1].contains(this.self.current)
+    );
+  };
+
   shouldClickDismiss = (event) => {
     var target = event.target;
     // This piece of code isolates targets which are fake clicked by things
@@ -50,6 +61,10 @@ export default class Modal extends React.Component {
       return false;
     }
     if (target === this.self.current || this.self.current.contains(target)) {
+      return false;
+    }
+    // Don't dismiss when interacting with another modal stacked on top.
+    if (!this.isTopmostModal()) {
       return false;
     }
     return true;

--- a/src/components/modals/ModalMaterials.js
+++ b/src/components/modals/ModalMaterials.js
@@ -1,0 +1,280 @@
+/* eslint-disable no-prototype-builtins */
+import React from 'react';
+import PropTypes from 'prop-types';
+import Modal from './Modal';
+import BooleanWidget from '../widgets/BooleanWidget';
+import ColorWidget from '../widgets/ColorWidget';
+import InputWidget from '../widgets/InputWidget';
+import NumberWidget from '../widgets/NumberWidget';
+import SelectWidget from '../widgets/SelectWidget';
+import Vec2Widget from '../widgets/Vec2Widget';
+
+/**
+ * Modal listing the <a-material> assets of the scene.
+ *
+ * Acts both as a picker (when opened from the material property widget, the
+ * selected material can be applied to the property) and as a live editor:
+ * property changes are set on the <a-material> element, updating every entity
+ * sharing the material.
+ */
+export default class ModalMaterials extends React.Component {
+  static propTypes = {
+    isOpen: PropTypes.bool,
+    onClose: PropTypes.func,
+    pickEnabled: PropTypes.bool,
+    selectedMaterial: PropTypes.string
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpen: this.props.isOpen,
+      materials: [],
+      selectedEl: null
+    };
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    if (state.isOpen !== props.isOpen) {
+      return { isOpen: props.isOpen };
+    }
+    return null;
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.isOpen && !prevProps.isOpen) {
+      this.refresh();
+    }
+  }
+
+  refresh() {
+    const materials = Array.from(document.querySelectorAll('a-material'));
+    const value = this.props.selectedMaterial;
+    let selectedEl = null;
+    if (value) {
+      if (value[0] === '#') {
+        selectedEl = materials.find((el) => el.id === value.substring(1));
+      } else {
+        selectedEl = materials.find((el) => el.inlineString === value);
+      }
+    }
+    this.setState({
+      materials: materials,
+      selectedEl: selectedEl || materials[0] || null
+    });
+  }
+
+  onClose = () => {
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
+  };
+
+  pick = () => {
+    const el = this.state.selectedEl;
+    if (!el || !this.props.onClose) return;
+    this.props.onClose(el.id ? '#' + el.id : el.inlineString);
+  };
+
+  createMaterial = () => {
+    let n = 1;
+    while (document.getElementById('material-' + n)) {
+      n++;
+    }
+    const el = document.createElement('a-material');
+    el.id = 'material-' + n;
+    const sceneEl = AFRAME.scenes[0];
+    let assetsEl = sceneEl.querySelector('a-assets');
+    if (!assetsEl) {
+      assetsEl = document.createElement('a-assets');
+      sceneEl.appendChild(assetsEl);
+    }
+    assetsEl.appendChild(el);
+    this.setState({
+      materials: Array.from(document.querySelectorAll('a-material')),
+      selectedEl: el
+    });
+  };
+
+  updateProperty = (name, value) => {
+    const el = this.state.selectedEl;
+    const propDef = el.schema[name];
+    let stringValue;
+    if (value === null || value === undefined) {
+      stringValue = '';
+    } else if (typeof value === 'object') {
+      stringValue = propDef.stringify(value);
+    } else {
+      stringValue = String(value);
+    }
+    el.setAttribute(name, stringValue);
+    // Attribute changes are picked up by a MutationObserver (asynchronous);
+    // apply synchronously so swatches and dependent widgets refresh right away.
+    el.attributeChangedCallback(name.toLowerCase(), null, stringValue);
+    this.forceUpdate();
+  };
+
+  getMaterialTitle(el) {
+    return el.id ? '#' + el.id : el.inlineString || '(inline)';
+  }
+
+  renderSwatch(el) {
+    let color = '#888';
+    let imageSrc = null;
+    const material = el.getMaterial();
+    if (material && material.color) {
+      color = '#' + material.color.getHexString();
+    }
+    const image = material && material.map && material.map.image;
+    if (image && image.src) {
+      imageSrc = image.src;
+    }
+    return (
+      <span className="materialSwatch" style={{ backgroundColor: color }}>
+        {imageSrc ? <img src={imageSrc} /> : null}
+      </span>
+    );
+  }
+
+  renderMaterialsList() {
+    const materials = this.state.materials;
+    if (materials.length === 0) {
+      return <p>No &lt;a-material&gt; assets in the scene.</p>;
+    }
+    return (
+      <ul>
+        {materials.map((el, idx) => (
+          <li
+            key={el.id || el.inlineString || idx}
+            className={this.state.selectedEl === el ? 'selected' : ''}
+            onClick={() => this.setState({ selectedEl: el })}
+            onDoubleClick={this.props.pickEnabled ? this.pick : undefined}
+            title={this.getMaterialTitle(el)}
+          >
+            {this.renderSwatch(el)}
+            <span className="title">{this.getMaterialTitle(el)}</span>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  renderPropertyRow(el, key) {
+    const propDef = el.schema[key];
+    const value = el.data[key];
+    const id = 'materialasset:' + key;
+    const onChange = (widgetName, widgetValue) =>
+      this.updateProperty(key, widgetValue);
+    const widgetProps = { id: id, name: key, onChange: onChange, value: value };
+    let widget;
+
+    if (key === 'shader') {
+      // Shader cannot be changed after the material is created.
+      widget = <span title="Shader cannot be changed">{el.data.shader}</span>;
+    } else if (propDef.oneOf && propDef.oneOf.length > 0) {
+      widget = <SelectWidget {...widgetProps} options={propDef.oneOf} />;
+    } else if (propDef.type === 'map') {
+      // Commit on blur; a partial URL or selector is not worth loading.
+      widget = (
+        <InputWidget
+          id={id}
+          name={key}
+          onBlur={onChange}
+          value={value}
+          schema={propDef}
+        />
+      );
+    } else {
+      switch (propDef.type) {
+        case 'number': {
+          widget = (
+            <NumberWidget
+              {...widgetProps}
+              min={propDef.hasOwnProperty('min') ? propDef.min : -Infinity}
+              max={propDef.hasOwnProperty('max') ? propDef.max : Infinity}
+            />
+          );
+          break;
+        }
+        case 'int':
+        case 'time': {
+          widget = <NumberWidget {...widgetProps} precision={0} />;
+          break;
+        }
+        case 'vec2': {
+          widget = <Vec2Widget {...widgetProps} />;
+          break;
+        }
+        case 'color': {
+          widget = <ColorWidget {...widgetProps} />;
+          break;
+        }
+        case 'boolean': {
+          widget = <BooleanWidget {...widgetProps} />;
+          break;
+        }
+        default: {
+          widget = (
+            <InputWidget
+              id={id}
+              name={key}
+              onBlur={onChange}
+              value={value}
+              schema={propDef}
+            />
+          );
+        }
+      }
+    }
+
+    return (
+      <div className="propertyRow" key={key}>
+        <label
+          htmlFor={id}
+          className="text"
+          title={key + ' - type: ' + propDef.type}
+        >
+          {key}
+        </label>
+        {widget}
+      </div>
+    );
+  }
+
+  renderEditor() {
+    const el = this.state.selectedEl;
+    if (!el || !el.schema) return null;
+    const keys = Object.keys(el.schema).sort();
+    return keys.map((key) => this.renderPropertyRow(el, key));
+  }
+
+  render() {
+    return (
+      <Modal
+        id="materialsModal"
+        title="Material Assets"
+        isOpen={this.state.isOpen}
+        onClose={this.onClose}
+      >
+        <div className="materialsModal">
+          <div className="materialsList">
+            {this.renderMaterialsList()}
+            <div className="materialsActions">
+              <button onClick={this.createMaterial}>NEW MATERIAL</button>
+              {this.props.pickEnabled && (
+                <button
+                  onClick={this.pick}
+                  disabled={!this.state.selectedEl}
+                  title="Set the material property to the selected material asset"
+                >
+                  USE SELECTED
+                </button>
+              )}
+            </div>
+          </div>
+          <div className="materialsEditor">{this.renderEditor()}</div>
+        </div>
+      </Modal>
+    );
+  }
+}

--- a/src/components/modals/ModalMaterials.js
+++ b/src/components/modals/ModalMaterials.js
@@ -7,6 +7,7 @@ import ColorWidget from '../widgets/ColorWidget';
 import InputWidget from '../widgets/InputWidget';
 import NumberWidget from '../widgets/NumberWidget';
 import SelectWidget from '../widgets/SelectWidget';
+import TextureWidget from '../widgets/TextureWidget';
 import Vec2Widget from '../widgets/Vec2Widget';
 
 /**
@@ -40,6 +41,21 @@ export default class ModalMaterials extends React.Component {
     }
     return null;
   }
+
+  componentDidMount() {
+    // Textures load asynchronously; refresh swatches and widgets when they do.
+    document.addEventListener('materialtextureloaded', this.onTextureLoaded);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('materialtextureloaded', this.onTextureLoaded);
+  }
+
+  onTextureLoaded = () => {
+    if (this.state.isOpen) {
+      this.forceUpdate();
+    }
+  };
 
   componentDidUpdate(prevProps) {
     if (this.props.isOpen && !prevProps.isOpen) {
@@ -174,16 +190,8 @@ export default class ModalMaterials extends React.Component {
     } else if (propDef.oneOf && propDef.oneOf.length > 0) {
       widget = <SelectWidget {...widgetProps} options={propDef.oneOf} />;
     } else if (propDef.type === 'map') {
-      // Commit on blur; a partial URL or selector is not worth loading.
-      widget = (
-        <InputWidget
-          id={id}
-          name={key}
-          onBlur={onChange}
-          value={value}
-          schema={propDef}
-        />
-      );
+      // Opens the textures modal, stacked on top of this one.
+      widget = <TextureWidget {...widgetProps} />;
     } else {
       switch (propDef.type) {
         case 'number': {

--- a/src/components/modals/ModalMaterials.js
+++ b/src/components/modals/ModalMaterials.js
@@ -112,6 +112,32 @@ export default class ModalMaterials extends React.Component {
     });
   };
 
+  removeMaterial = () => {
+    const el = this.state.selectedEl;
+    // Inline materials are owned by their `material(...)` definitions.
+    if (!el || !el.id) return;
+    const material = el.getMaterial();
+    const users = Array.from(
+      document.querySelectorAll('a-scene [material]')
+    ).filter(
+      (entity) =>
+        entity.isEntity && entity.components?.material?.material === material
+    );
+    const message = users.length
+      ? 'Material `#' +
+        el.id +
+        '` is used by ' +
+        users.length +
+        ' entit' +
+        (users.length === 1 ? 'y' : 'ies') +
+        '. Do you really want to remove it?'
+      : 'Do you really want to remove material `#' + el.id + '`?';
+    if (!confirm(message)) return;
+    el.parentNode.removeChild(el);
+    const materials = Array.from(document.querySelectorAll('a-material'));
+    this.setState({ materials, selectedEl: materials[0] || null });
+  };
+
   updateProperty = (name, value) => {
     const el = this.state.selectedEl;
     const propDef = el.schema[name];
@@ -278,6 +304,17 @@ export default class ModalMaterials extends React.Component {
                   USE SELECTED
                 </button>
               )}
+              <button
+                onClick={this.removeMaterial}
+                disabled={!this.state.selectedEl || !this.state.selectedEl.id}
+                title={
+                  this.state.selectedEl && !this.state.selectedEl.id
+                    ? 'Inline materials are owned by their material(...) definition'
+                    : 'Remove the selected material asset'
+                }
+              >
+                DELETE
+              </button>
             </div>
           </div>
           <div className="materialsEditor">{this.renderEditor()}</div>

--- a/src/components/modals/ModalTextures.js
+++ b/src/components/modals/ModalTextures.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { faSearch } from '@fortawesome/free-solid-svg-icons';
+import { faSearch, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
 import { AwesomeIcon } from '../AwesomeIcon';
 import Events from '../../lib/Events';
 import Modal from './Modal';
@@ -217,6 +217,18 @@ export default class ModalTextures extends React.Component {
     this.setState({ filterText: e.target.value });
   };
 
+  deleteAsset = (image, event) => {
+    event.stopPropagation();
+    if (!confirm('Do you really want to remove asset `#' + image.id + '`?')) {
+      return;
+    }
+    const assetEl = document.getElementById(image.id);
+    if (assetEl && assetEl.parentNode) {
+      assetEl.parentNode.removeChild(assetEl);
+    }
+    this.generateFromAssets();
+  };
+
   renderRegistryImages() {
     var self = this;
     let selectSample = function (image) {
@@ -411,6 +423,13 @@ export default class ModalTextures extends React.Component {
                         <span>
                           {image.width} x {image.height}
                         </span>
+                        <a
+                          className="button delete-asset"
+                          title="Remove asset"
+                          onClick={this.deleteAsset.bind(this, image)}
+                        >
+                          <AwesomeIcon icon={faTrashAlt} />
+                        </a>
                       </div>
                     </li>
                   );

--- a/src/components/widgets/MaterialWidget.js
+++ b/src/components/widgets/MaterialWidget.js
@@ -1,0 +1,151 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Events from '../../lib/Events';
+
+/**
+ * Widget for the `material` property type: a reference to an <a-material> asset
+ * (e.g., `#myMaterial`) or an inline `material(...)` definition.
+ *
+ * The value is edited as a raw string and committed on blur, like selector types.
+ * The swatch opens the materials modal to pick another material asset or edit the
+ * existing ones.
+ */
+export default class MaterialWidget extends React.Component {
+  static propTypes = {
+    id: PropTypes.string,
+    name: PropTypes.string.isRequired,
+    onBlur: PropTypes.func,
+    value: PropTypes.string
+  };
+
+  static defaultProps = {
+    value: ''
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = { value: this.props.value || '' };
+    this.input = React.createRef();
+    this.canvas = React.createRef();
+  }
+
+  componentDidMount() {
+    this.paintSwatch();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.value !== prevProps.value) {
+      this.setState({ value: this.props.value || '' });
+    }
+    this.paintSwatch();
+  }
+
+  resolveMaterialEl = (value) => {
+    if (!value) return null;
+    if (value[0] === '#') {
+      const el = document.getElementById(value.substring(1));
+      return el && el.isMaterialAsset ? el : null;
+    }
+    if (value.indexOf('material(') === 0) {
+      return (
+        Array.from(document.querySelectorAll('a-material')).find(
+          (el) => el.inlineString === value
+        ) || null
+      );
+    }
+    return null;
+  };
+
+  paintSwatch = () => {
+    const canvas = this.canvas.current;
+    if (!canvas) return;
+    const context = canvas.getContext('2d');
+    context.clearRect(0, 0, canvas.width, canvas.height);
+
+    const materialEl = this.resolveMaterialEl(this.state.value);
+    if (!materialEl) return;
+    const material = materialEl.getMaterial();
+    if (!material) return;
+
+    if (material.color) {
+      context.fillStyle = '#' + material.color.getHexString();
+      context.fillRect(0, 0, canvas.width, canvas.height);
+    }
+    const image = material.map && material.map.image;
+    if (image && image.width > 0) {
+      try {
+        context.drawImage(image, 0, 0, canvas.width, canvas.height);
+      } catch (e) {
+        // Some sources (e.g., detached video) cannot be drawn; keep the color.
+      }
+    }
+  };
+
+  commit = (value) => {
+    if (this.props.onBlur) {
+      this.props.onBlur(this.props.name, value);
+    }
+  };
+
+  onChange = (event) => {
+    this.setState({ value: event.target.value });
+  };
+
+  onBlur = (event) => {
+    this.commit(event.target.value);
+    this.paintSwatch();
+  };
+
+  onKeyDown = (event) => {
+    event.stopPropagation();
+    // enter
+    if (event.keyCode === 13) {
+      this.input.current.blur();
+    }
+  };
+
+  openDialog = () => {
+    Events.emit('openmaterialsmodal', this.state.value, (value) => {
+      if (value !== undefined && value !== null && value !== this.state.value) {
+        this.setState({ value: value });
+        this.commit(value);
+      }
+      // The material may have been edited in the modal without changing the
+      // reference; repaint once the modal closes.
+      setTimeout(this.paintSwatch, 0);
+    });
+  };
+
+  render() {
+    const materialEl = this.resolveMaterialEl(this.state.value);
+    const hint = materialEl
+      ? 'Material asset: ' +
+        (materialEl.id ? '#' + materialEl.id : materialEl.inlineString) +
+        '\nClick the swatch to pick or edit materials'
+      : 'Click the swatch to pick or edit materials';
+
+    return (
+      <span className="texture">
+        <input
+          id={this.props.id}
+          ref={this.input}
+          className="map_value string"
+          type="text"
+          title={hint}
+          value={this.state.value}
+          onChange={this.onChange}
+          onBlur={this.onBlur}
+          onKeyDown={this.onKeyDown}
+          spellCheck="false"
+        />
+        <canvas
+          ref={this.canvas}
+          width="32"
+          height="16"
+          title={hint}
+          onClick={this.openDialog}
+        />
+      </span>
+    );
+  }
+}

--- a/src/style/index.styl
+++ b/src/style/index.styl
@@ -57,6 +57,7 @@ body.aframe-inspector-opened
   @import './help';
   @import './select';
   @import './textureModal';
+  @import './materialModal';
   @import './viewport';
   @import './widgets';
 

--- a/src/style/materialModal.styl
+++ b/src/style/materialModal.styl
@@ -1,0 +1,70 @@
+#materialsModal .modal-content
+  max-width 760px
+  width calc(100% - 100px)
+
+.materialsModal
+  display flex
+  gap 16px
+
+.materialsModal .materialsList
+  display flex
+  flex-direction column
+  flex-shrink 0
+  width 240px
+
+.materialsModal .materialsList ul
+  list-style none
+  margin 0
+  max-height calc(100vh - 320px)
+  overflow-y auto
+  padding 0
+
+.materialsModal .materialsList li
+  align-items center
+  border-radius 2px
+  cursor pointer
+  display flex
+  gap 8px
+  margin 2px
+  overflow hidden
+  padding 6px 8px
+
+.materialsModal .materialsList li.selected,
+.materialsModal .materialsList li:hover
+  box-shadow 0 0 0 2px var(--color-primary)
+
+.materialsModal .materialsList li .title
+  color var(--color-property-defined)
+  font-weight 600
+  overflow hidden
+  text-overflow ellipsis
+  white-space nowrap
+
+.materialsModal .materialsActions
+  display flex
+  flex-direction column
+  gap 4px
+  margin-top 8px
+
+.materialSwatch
+  border 1px solid var(--color-base-content)
+  border-radius 2px
+  display inline-block
+  flex-shrink 0
+  height 18px
+  overflow hidden
+  width 28px
+
+.materialSwatch img
+  display block
+  height 100%
+  object-fit cover
+  width 100%
+
+.materialsModal .materialsEditor
+  flex-grow 1
+  max-height calc(100vh - 280px)
+  overflow-y auto
+
+.materialsModal .materialsEditor .propertyRow
+  padding 2px 10px 2px 0

--- a/src/style/materialModal.styl
+++ b/src/style/materialModal.styl
@@ -28,6 +28,7 @@
   margin 2px
   overflow hidden
   padding 6px 8px
+  user-select none
 
 .materialsModal .materialsList li.selected,
 .materialsModal .materialsList li:hover

--- a/src/style/textureModal.styl
+++ b/src/style/textureModal.styl
@@ -70,6 +70,7 @@
   cursor pointer
   margin 8px
   overflow hidden
+  position relative
   width 155px
 
 .gallery li.selected,
@@ -217,3 +218,13 @@
 .texture canvas
   border 1px solid var(--color-base-100)
   cursor pointer
+
+.gallery li .delete-asset
+  bottom 6px
+  color var(--color-base-content)
+  cursor pointer
+  position absolute
+  right 8px
+
+.gallery li .delete-asset:hover
+  color var(--color-primary)


### PR DESCRIPTION
## Description

Companion to aframevr/aframe#5846 (materials as assets and property type).

### Material property widget

The new `material` property type references an `<a-material>` asset by selector (`#myMaterial`) or an inline `material(...)` definition, and its parsed value is a `THREE.Material`. Without these changes, the property fell through to the generic `InputWidget`, which parses and commits on **every keystroke** — typing a partial selector like `#crate` immediately committed a null material and detached the entity from its shared material while typing.

The property is now rendered by a dedicated `MaterialWidget`: the raw reference string committed on blur (like `selector`/`selectorAll`), plus a swatch previewing the referenced material's color/texture.

### Material Assets modal (picker + live editor)

Clicking the swatch opens a Material Assets modal that:

- lists every `<a-material>` in the scene with a color/texture swatch,
- applies the selected asset to the property (USE SELECTED button or double-click),
- edits the selected material's properties with schema-driven widgets (base material + shader schema, `shader` shown read-only since it cannot change after creation) — edits apply live to every entity sharing the material; map properties use the texture picker, stacked on top of the materials modal (`Modal` is now stacking-aware: only the topmost open modal reacts to ESC/outside clicks),
- creates new `<a-material>` assets under `<a-assets>` (NEW MATERIAL button),
- deletes the selected material asset (DELETE button, disabled for inline materials; the confirmation mentions how many entities use the material).

The textures modal also gets a trash button on each asset image to remove it from `<a-assets>`.

The example scene includes two shared `<a-material>` assets, an inline definition, and entities using them (requires an A-Frame build with aframevr/aframe#5846; with older builds these entities render with a default material and a warning).

Verified against an aframe build of the PR branch: picking switches the entity's shared material (textures included), editing roughness/color in the modal updates all entities sharing the material live, the reset button returns the entity to its own component-managed material, and typing partial selectors no longer detaches the material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


