### PR TITLE
fix: unfocus UI inputs on viewport click, refuse duplicate id in ID input

### DIFF
--- a/src/components/components/CommonComponents.js
+++ b/src/components/components/CommonComponents.js
@@ -12,19 +12,43 @@ import Events from '../../lib/Events';
 import { saveBlob } from '../../lib/utils';
 import GLTFIcon from '../../../assets/gltf.svg';
 
-// @todo Take this out and use updateEntity?
-function changeId(componentName, value) {
-  var entity = AFRAME.INSPECTOR.selectedEntity;
-  if (entity.id !== value) {
-    entity.id = value;
-    Events.emit('entityidchange', entity);
-  }
-}
-
 export default class CommonComponents extends React.Component {
   static propTypes = {
     entity: PropTypes.object
   };
+
+  state = {
+    duplicateId: null,
+    idInputKey: 0
+  };
+
+  changeId = (componentName, value) => {
+    var entity = AFRAME.INSPECTOR.selectedEntity;
+    if (entity.id !== value) {
+      // Ids must be unique; committing a duplicate id breaks entity lookups
+      // done with getElementById or querySelector in components. Refuse the
+      // value, show a message and remount the input so it displays the
+      // entity's current id again.
+      if (value && document.getElementById(value)) {
+        this.setState((state) => ({
+          duplicateId: value,
+          idInputKey: state.idInputKey + 1
+        }));
+        return;
+      }
+      this.setState({ duplicateId: null });
+      entity.id = value;
+      Events.emit('entityidchange', entity);
+    } else {
+      this.setState({ duplicateId: null });
+    }
+  };
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.entity !== this.props.entity && this.state.duplicateId) {
+      this.setState({ duplicateId: null });
+    }
+  }
 
   onEntityUpdate = (detail) => {
     if (detail.entity !== this.props.entity) {
@@ -125,12 +149,19 @@ export default class CommonComponents extends React.Component {
               ID
             </label>
             <InputWidget
-              onBlur={changeId}
+              key={this.state.idInputKey}
+              onBlur={this.changeId}
               entity={entity}
               name="id"
               value={entity.id}
             />
           </div>
+          {this.state.duplicateId !== null && (
+            <div className="propertyRowError">
+              The id &quot;{this.state.duplicateId}&quot; is already used by
+              another element, the previous id was restored.
+            </div>
+          )}
           <div className="propertyRow">
             <label className="text">class</label>
             <span>{entity.getAttribute('class')}</span>

--- a/src/lib/raycaster.js
+++ b/src/lib/raycaster.js
@@ -73,7 +73,14 @@ export function initRaycaster(inspector) {
     if (event instanceof CustomEvent) {
       return;
     }
-    event.preventDefault();
+    // Don't preventDefault on left click: it would suppress the browser's
+    // default focus transfer, leaving a focused panel input (e.g. the id
+    // field) focused while the selection changes underneath it, so its blur
+    // handler would later commit a stale value to the newly selected entity.
+    if (event.button !== 0) {
+      // Middle click: prevent autoscroll so it can be used for zoom.
+      event.preventDefault();
+    }
     const array = getMousePosition(
       inspector.container,
       event.clientX,

--- a/src/style/components.styl
+++ b/src/style/components.styl
@@ -137,6 +137,11 @@
   .text
     width 90px
 
+.propertyRowError
+  color var(--color-error)
+  font-size 13px
+  padding 2px 30px 2px 15px
+
 .propertyRowDefined .text
   color var(--color-property-defined)
   font-weight 600

--- a/src/style/index.styl
+++ b/src/style/index.styl
@@ -306,9 +306,6 @@ body.aframe-inspector-opened
   .hide
     display none
 
-  .a-canvas.state-dragging
-    cursor grabbing
-
   #rightPanel
     align-items stretch
     display flex
@@ -329,10 +326,6 @@ body.aframe-inspector-opened
   #viewportBar,
   #rightPanel
     pointer-events all
-
-  .aframe-inspector-opened a-scene .a-canvas
-    background-color #191919
-    z-index 9998
 
   .toggle-sidebar
     align-items center

--- a/src/style/index.styl
+++ b/src/style/index.styl
@@ -12,6 +12,11 @@ body.aframe-inspector-opened
   margin 0
   overflow hidden
 
+  a-scene .a-canvas
+    // mousedown default action is no longer prevented (see raycaster.js), so
+    // block drag-started text selection from anchoring on the canvas
+    user-select none
+
 /* :where(:root) has zero specificity compared to :root, so any user defined :root will override the below rule */
 :where(:root) {
   color-scheme: dark;


### PR DESCRIPTION
Two improvements to the panel/viewport interaction:

## Unfocus UI inputs when clicking the viewport

`raycaster.js` called `event.preventDefault()` on every viewport `mousedown`, which cancels the browser's default focus transfer — so clicking the viewport never unfocused the currently focused panel input.

- Only `preventDefault()` non-left buttons now (still needed so middle-click zoom doesn't trigger the browser's autoscroll). Left-click performs the native focus transfer, so a focused input blurs — and commits its pending edit — before the selection changes.
- `user-select: none` added on the canvas, since `preventDefault()` was incidentally blocking drag-started text selection (drag-orbiting could otherwise select panel text).

## Refuse duplicate ids in the ID input

Typing an id that already belongs to another element was silently committed, producing a duplicate id in the document, which breaks entity lookups done with `getElementById`/`querySelector` (selector-type component properties, links between entities, …).

`changeId` now refuses such a value: a message is shown below the input and the input is remounted so it displays the entity's current id again.

> The id "aBox" is already used by another element, the previous id was restored.

<img width="1919" height="910" alt="Capture d’écran du 2026-07-13 09-31-29" src="https://github.com/user-attachments/assets/929675c3-0393-477d-992c-c3c2d8a7628c" />
<img width="1919" height="910" alt="Capture d’écran du 2026-07-13 09-31-36" src="https://github.com/user-attachments/assets/9dc73fd5-20d5-4c2a-8d70-a56f2a0b17c7" />

## Dead CSS cleanup

The `.aframe-inspector-opened a-scene .a-canvas` and `.a-canvas.state-dragging` rules in `index.styl` are nested under `#aframeInspector`, and the canvas is not a descendant of it, so they never matched (nothing in `src` adds the `state-dragging` class anyway). Removed; the new `user-select` rule lives under `body.aframe-inspector-opened`, which does match.

## Tested

On the examples page with headless Chromium: viewport left-click blurs a focused id input; typing an existing id is refused with the message shown, and the message clears on entity switch; a valid rename still works and emits `entityidchange`; canvas `user-select` is `none`; middle/right-click still `preventDefault`.

Same change on the aframe-editor fork: https://github.com/c-frame/aframe-editor/pull/79

🤖 Generated with [Claude Code](https://claude.com/claude-code)